### PR TITLE
Reduced djenne effect tenfold

### DIFF
--- a/common/production_methods/babylon_monuments.txt
+++ b/common/production_methods/babylon_monuments.txt
@@ -1,0 +1,19 @@
+﻿pm_default_building_mosque_of_djenne = {
+	texture = "gfx/interface/icons/production_method_icons/wonders.dds"
+
+	country_modifiers = {
+		workforce_scaled = {
+			interest_group_ig_devout_pol_str_mult = 0.1
+			state_education_access_add = 0.02
+		}
+	}
+
+	building_modifiers = {
+		#workforce_scaled = {
+		#}
+
+		level_scaled = {
+			building_employment_clergymen_add = 500
+		}
+	}
+}


### PR DESCRIPTION
The 20% (22% with colonial exploitation) global eductation modifier is insane, changed it to 2% which is a nice boost but not gamechanging, like all other monuments are supposed to be.