### PR TITLE
Babylon authority economy and migration (& Slavery)

### DIFF
--- a/common/laws/00_economic_system.txt
+++ b/common/laws/00_economic_system.txt
@@ -1,68 +1,55 @@
 ﻿# group = this is the law_group a law belongs to
 # icon = graphical icon shown in-game
 # modifier = {} modifier on country for having adopted this law
-
 law_traditionalism = {
 	group = lawgroup_economic_system
-	
 	icon = "gfx/interface/icons/law_icons/traditionalism.dds"
-	
 	progressiveness = -50
-	
 	disallowing_laws = {
 		law_per_capita_based_taxation
 		law_proportional_taxation
 		law_graduated_taxation
 		law_anarchy
 	}
-		
 	on_activate = {
 	}
-	
 	modifier = {
-		state_shopkeepers_investment_pool_efficiency_mult = -0.5
-		state_capitalists_investment_pool_efficiency_mult = -0.5
-		state_aristocrats_investment_pool_efficiency_mult = -0.20	
+		state_shopkeepers_investment_pool_efficiency_mult = -0.4
+		state_farmers_investment_pool_efficiency_mult = -0.25
+		state_capitalists_investment_pool_efficiency_mult = -0.6
 		state_bureaucracy_population_base_cost_factor_mult = -0.25
 		state_tax_capacity_mult = -0.25
 		country_private_construction_allocation_mult = 0.25
-		
 		country_subsidies_bg_infrastructure = yes
 		country_subsidies_bg_trade = yes
 	}
-	
 	possible_political_movements = {
 		law_interventionism
 		law_command_economy
 		law_agrarianism
 		law_laissez_faire
 	}
-
 	# no pop support because movements are impossible
-	
 	pop_support = {
 		value = 0
 	}
-
 	build_from_investment_pool = {
 		bg_agriculture
 		bg_plantations
 		bg_ranching
-	}	
-	
+	}
 	# AI should never switch back to traditionalism
 	ai_will_do = {
 		always = no
 	}
-
-	ai_enact_weight_modifier = { #Petitions
+	ai_enact_weight_modifier = {
+		#Petitions
 		value = 0
-		
 		if = {
-			limit = { 
+			limit = {
 				has_journal_entry = je_government_petition
 				has_variable = desired_law_var
-                scope:law = var:desired_law_var
+				scope:law = var:desired_law_var
 			}
 			add = 750
 		}
@@ -71,28 +58,24 @@ law_traditionalism = {
 
 law_interventionism = {
 	group = lawgroup_economic_system
-	
 	icon = "gfx/interface/icons/law_icons/interventionism.dds"
-	
 	progressiveness = 50
-	
 	disallowing_laws = {
 		law_serfdom
 		law_anarchy
 	}
-	
 	on_activate = {
 	}
-	
 	unlocking_technologies = {
 		manufacturies
 	}
-	
 	modifier = {
 		country_subsidies_all = yes
 		country_private_construction_allocation_mult = 0.5
+		state_shopkeepers_investment_pool_efficiency_mult = 0.25
+		state_farmers_investment_pool_efficiency_mult = 0.25
+		state_aristocrats_investment_pool_efficiency_mult = -0.05
 	}
-
 	build_from_investment_pool = {
 		bg_agriculture
 		bg_plantations
@@ -106,7 +89,6 @@ law_interventionism = {
 		bg_oil_extraction
 		bg_infrastructure
 	}
-	
 	possible_political_movements = {
 		law_command_economy
 		law_agrarianism
@@ -114,18 +96,17 @@ law_interventionism = {
 		law_cooperative_ownership
 		law_industry_banned
 	}
-
 	pop_support = {
 		value = 0
 		add = {
-			desc = "POP_CAPITALISTS"			
+			desc = "POP_CAPITALISTS"
 			if = {
 				limit = {
 					owner = {
-						OR = { 
-							has_law = law_type:law_agrarianism 
-							has_law = law_type:law_traditionalism 
-							has_law = law_type:law_industry_banned 
+						OR = {
+							has_law = law_type:law_agrarianism
+							has_law = law_type:law_traditionalism
+							has_law = law_type:law_industry_banned
 						}
 					}
 					is_pop_type = capitalists
@@ -134,17 +115,16 @@ law_interventionism = {
 			}
 		}
 	}
-
 	pop_support = {
 		value = 0
 		add = {
-			desc = "POP_CAPITALISTS"			
+			desc = "POP_CAPITALISTS"
 			if = {
 				limit = {
 					owner = {
-						OR = { 
-							has_law = law_type:law_agrarianism 
-							has_law = law_type:law_traditionalism 
+						OR = {
+							has_law = law_type:law_agrarianism
+							has_law = law_type:law_traditionalism
 						}
 					}
 					is_pop_type = capitalists
@@ -153,15 +133,14 @@ law_interventionism = {
 			}
 		}
 	}
-
-	ai_enact_weight_modifier = { #Petitions
+	ai_enact_weight_modifier = {
+		#Petitions
 		value = 0
-		
 		if = {
-			limit = { 
+			limit = {
 				has_journal_entry = je_government_petition
 				has_variable = desired_law_var
-                scope:law = var:desired_law_var
+				scope:law = var:desired_law_var
 			}
 			add = 750
 		}
@@ -170,35 +149,28 @@ law_interventionism = {
 
 law_agrarianism = {
 	group = lawgroup_economic_system
-	
 	icon = "gfx/interface/icons/law_icons/agrarianism.dds"
-	
 	progressiveness = 0
-	
 	disallowing_laws = {
 		law_anarchy
-	}	
-	
+	}
 	unlocking_technologies = {
 		romanticism
 	}
-	
 	on_activate = {
 	}
-	
 	modifier = {
-		state_aristocrats_investment_pool_efficiency_mult = 0.5
-		state_farmers_investment_pool_efficiency_mult = 0.5
-		state_capitalists_investment_pool_efficiency_mult = -0.25
+		state_aristocrats_investment_pool_efficiency_mult = 0.6
+		state_farmers_investment_pool_efficiency_mult = 0.8
+		state_shopkeepers_investment_pool_efficiency_mult = -0.25
+		state_capitalists_investment_pool_efficiency_mult = -0.4
 		country_private_construction_allocation_mult = 0.5
-		
 		country_subsidies_bg_agriculture = yes
 		country_subsidies_bg_ranching = yes
 		country_subsidies_bg_plantations = yes
 		country_subsidies_bg_infrastructure = yes
 		country_subsidies_bg_trade = yes
 	}
-
 	build_from_investment_pool = {
 		bg_agriculture
 		bg_plantations
@@ -209,24 +181,22 @@ law_agrarianism = {
 		bg_rubber
 		bg_fishing
 	}
-	
 	possible_political_movements = {
 		law_interventionism
 		law_command_economy
 		law_laissez_faire
 		law_cooperative_ownership
 	}
-	
 	pop_support = {
 		value = 0
 		add = {
-			desc = "POP_FARMERS"			
+			desc = "POP_FARMERS"
 			if = {
 				limit = {
 					owner = {
-						OR = { 
-							has_law = law_type:law_interventionism 
-							has_law = law_type:law_laissez_faire 
+						OR = {
+							has_law = law_type:law_interventionism
+							has_law = law_type:law_laissez_faire
 							has_law = law_type:law_traditionalism
 						}
 					}
@@ -236,13 +206,13 @@ law_agrarianism = {
 			}
 		}
 		add = {
-			desc = "POP_ARISTOCRATS"			
+			desc = "POP_ARISTOCRATS"
 			if = {
 				limit = {
 					owner = {
-						OR = { 
-							has_law = law_type:law_interventionism 
-							has_law = law_type:law_laissez_faire 
+						OR = {
+							has_law = law_type:law_interventionism
+							has_law = law_type:law_laissez_faire
 						}
 					}
 					is_pop_type = aristocrats
@@ -251,22 +221,20 @@ law_agrarianism = {
 			}
 		}
 	}
-		
 	ai_will_do = {
 		OR = {
 			has_law = law_type:law_traditionalism
 			literacy_rate < 0.4
 		}
 	}
-
-	ai_enact_weight_modifier = { #Petitions
+	ai_enact_weight_modifier = {
+		#Petitions
 		value = 0
-		
 		if = {
-			limit = { 
+			limit = {
 				has_journal_entry = je_government_petition
 				has_variable = desired_law_var
-                scope:law = var:desired_law_var
+				scope:law = var:desired_law_var
 			}
 			add = 750
 		}
@@ -275,14 +243,11 @@ law_agrarianism = {
 
 law_industry_banned = {
 	group = lawgroup_economic_system
-	
 	icon = "gfx/interface/icons/law_icons/industry_banned.dds"
 	progressiveness = 0
-	
 	unlocking_technologies = {
 		romanticism
 	}
-
 	on_activate = {
 		custom_tooltip = industry_banned_tt
 		custom_tooltip = {
@@ -339,12 +304,12 @@ law_industry_banned = {
 			}
 		}
 	}
-
 	modifier = {
-		building_group_bg_agriculture_throughput_mult = 0.1
+		building_group_bg_agriculture_throughput_mult = 0.15
 		state_expected_sol_mult = -0.1
 		interest_group_ig_rural_folk_pol_str_mult = 0.5
-		state_aristocrats_investment_pool_contribution_add = 0.25
+		state_farmers_investment_pool_efficiency_mult = 1
+		state_aristocrats_investment_pool_contribution_add = 0.35
 		country_private_construction_allocation_mult = 0.5
 		country_production_tech_cost_mult = 0.25
 		country_production_tech_spread_mult = -0.25
@@ -354,30 +319,27 @@ law_industry_banned = {
 		country_subsidies_bg_infrastructure = yes
 		country_subsidies_bg_trade = yes
 	}
-
 	build_from_investment_pool = {
 		bg_agriculture
 		bg_plantations
 		bg_ranching
 		bg_infrastructure
 	}
-	
 	possible_political_movements = {
 		law_interventionism
 		law_command_economy
 		law_laissez_faire
 	}
-
 	pop_support = {
 		value = 0
 		add = {
-			desc = "POP_FARMERS"			
+			desc = "POP_FARMERS"
 			if = {
 				limit = {
 					owner = {
-						OR = { 
-							has_law = law_type:law_interventionism 
-							has_law = law_type:law_laissez_faire 
+						OR = {
+							has_law = law_type:law_interventionism
+							has_law = law_type:law_laissez_faire
 							has_law = law_type:law_traditionalism
 						}
 					}
@@ -387,57 +349,48 @@ law_industry_banned = {
 			}
 		}
 	}
-
 	ai_will_do = {
 		always = no
 	}
-
-	ai_enact_weight_modifier = { #Petitions
+	ai_enact_weight_modifier = {
+		#Petitions
 		value = 0
-		
 		if = {
-			limit = { 
+			limit = {
 				has_journal_entry = je_government_petition
 				has_variable = desired_law_var
-                scope:law = var:desired_law_var
+				scope:law = var:desired_law_var
 			}
 			add = 750
 		}
 	}
 }
 
-
 law_laissez_faire = {
 	group = lawgroup_economic_system
-	
 	icon = "gfx/interface/icons/law_icons/laissez_faire.dds"
-	
 	progressiveness = 100
-	
 	disallowing_laws = {
 		law_serfdom
 		law_isolationism
 		law_anarchy
 	}
-	
 	unlocking_technologies = {
 		international_trade
 	}
-	
 	on_activate = {
 	}
-	
 	modifier = {
 		country_loan_interest_rate_mult = -0.15
-		state_shopkeepers_investment_pool_efficiency_mult = 0.25	
-		state_capitalists_investment_pool_efficiency_mult = 0.25
+		state_shopkeepers_investment_pool_efficiency_mult = 0.5
+		state_capitalists_investment_pool_efficiency_mult = 0.3
+		interest_group_ig_industrialists_pol_str_mult = 0.25
+		country_trade_route_competitiveness_mult = 0.1
 		country_private_construction_allocation_mult = 0.75
-		
 		country_subsidies_bg_infrastructure = yes
 		country_subsidies_bg_trade = yes
 		country_private_buildings_protected = yes
 	}
-
 	build_from_investment_pool = {
 		bg_manufacturing
 		bg_mining
@@ -446,9 +399,8 @@ law_laissez_faire = {
 		bg_oil_extraction
 		bg_infrastructure
 		bg_whaling
-		bg_fishing	
+		bg_fishing
 	}
-	
 	possible_political_movements = {
 		law_interventionism
 		law_command_economy
@@ -456,18 +408,17 @@ law_laissez_faire = {
 		law_cooperative_ownership
 		law_industry_banned
 	}
-
 	pop_support = {
 		value = 0
 		add = {
-			desc = "POP_CAPITALISTS"			
+			desc = "POP_CAPITALISTS"
 			if = {
 				limit = {
 					owner = {
-						OR = { 
-							has_law = law_type:law_agrarianism 
-							has_law = law_type:law_traditionalism 
-							has_law = law_type:law_industry_banned 
+						OR = {
+							has_law = law_type:law_agrarianism
+							has_law = law_type:law_traditionalism
+							has_law = law_type:law_industry_banned
 						}
 					}
 					is_pop_type = capitalists
@@ -476,15 +427,14 @@ law_laissez_faire = {
 			}
 		}
 	}
-
-	ai_enact_weight_modifier = { #Petitions
+	ai_enact_weight_modifier = {
+		#Petitions
 		value = 0
-		
 		if = {
-			limit = { 
+			limit = {
 				has_journal_entry = je_government_petition
 				has_variable = desired_law_var
-                scope:law = var:desired_law_var
+				scope:law = var:desired_law_var
 			}
 			add = 750
 		}
@@ -493,33 +443,27 @@ law_laissez_faire = {
 
 law_cooperative_ownership = {
 	group = lawgroup_economic_system
-	
 	icon = "gfx/interface/icons/law_icons/cooperative_ownership.dds"
-	
 	progressiveness = 100
-	
 	disallowing_laws = {
 		law_serfdom
 	}
-	
 	unlocking_laws = {
-		law_council_republic			
+		law_council_republic
 	}
-	
-	on_activate = {		
+	on_activate = {
 		custom_tooltip = {
 			text = enact_law_radical_leftist_economy_warning_desc
-		}	
+		}
 	}
-	
 	modifier = {
-		state_shopkeepers_investment_pool_efficiency_mult = 0.35	
-		state_farmers_investment_pool_efficiency_mult = 0.35
+		country_law_enactment_time_mult = 0.15
+		state_shopkeepers_investment_pool_efficiency_mult = 0.40
+		state_farmers_investment_pool_efficiency_mult = 0.40
+		country_trade_route_competitiveness_mult = -0.1
 		country_private_construction_allocation_mult = 0.35
-
 		country_subsidies_all = yes
 	}
-	
 	build_from_investment_pool = {
 		bg_manufacturing
 		bg_mining
@@ -528,26 +472,24 @@ law_cooperative_ownership = {
 		bg_oil_extraction
 		bg_infrastructure
 		bg_whaling
-		bg_fishing	
-	}	
-	
+		bg_fishing
+	}
 	possible_political_movements = {
 		law_interventionism
 		law_agrarianism
 		law_laissez_faire
 		law_command_economy
 	}
-
 	pop_support = {
 		value = 0
 		add = {
-			desc = "POP_CAPITALISTS"			
+			desc = "POP_CAPITALISTS"
 			if = {
 				limit = {
 					owner = {
-						OR = { 
-							has_law = law_type:law_agrarianism 
-							has_law = law_type:law_traditionalism 
+						OR = {
+							has_law = law_type:law_agrarianism
+							has_law = law_type:law_traditionalism
 						}
 					}
 					is_pop_type = capitalists
@@ -556,15 +498,14 @@ law_cooperative_ownership = {
 			}
 		}
 	}
-
-	ai_enact_weight_modifier = { #Petitions
+	ai_enact_weight_modifier = {
+		#Petitions
 		value = 0
-		
 		if = {
-			limit = { 
+			limit = {
 				has_journal_entry = je_government_petition
 				has_variable = desired_law_var
-                scope:law = var:desired_law_var
+				scope:law = var:desired_law_var
 			}
 			add = 750
 		}
@@ -573,41 +514,34 @@ law_cooperative_ownership = {
 
 law_command_economy = {
 	group = lawgroup_economic_system
-	
 	icon = "gfx/interface/icons/law_icons/command_economy.dds"
-	
 	progressiveness = 100
-	
 	disallowing_laws = {
 		law_serfdom
 		law_anarchy
 	}
-	
 	unlocking_technologies = {
 		central_planning
 	}
-	
 	unlocking_laws = {
 		law_autocracy
 		law_oligarchy
 		law_single_party_state
 		law_technocracy
-	}	
-	
+	}
 	on_activate = {
 		seize_investment_pool = yes
 		custom_tooltip = {
 			text = enact_law_radical_leftist_economy_warning_desc
-		}	
+		}
 	}
-	
 	modifier = {
 		country_subsidies_all = yes
 		country_disable_investment_pool = yes
-		
+		country_authority_add = 100
 		country_authority_mult = 0.25
+		country_trade_route_competitiveness_mult = -0.20
 	}
-	
 	possible_political_movements = {
 		law_interventionism
 		law_agrarianism
@@ -615,11 +549,10 @@ law_command_economy = {
 		law_cooperative_ownership
 		law_industry_banned
 	}
-
 	pop_support = {
 		value = 0
 		add = {
-			desc = "POP_BUREAUCRATS"			
+			desc = "POP_BUREAUCRATS"
 			if = {
 				limit = {
 					is_pop_type = bureaucrats
@@ -628,11 +561,10 @@ law_command_economy = {
 			}
 		}
 	}
-
 	pop_support = {
 		value = 0
 		add = {
-			desc = "POP_BUREAUCRATS"			
+			desc = "POP_BUREAUCRATS"
 			if = {
 				limit = {
 					is_pop_type = bureaucrats
@@ -641,7 +573,6 @@ law_command_economy = {
 			}
 		}
 	}
-	
 	ai_will_do = {
 		OR = {
 			has_law = law_type:law_council_republic
@@ -649,19 +580,18 @@ law_command_economy = {
 				exists = ruler
 				ruler = {
 					has_ideology = ideology:ideology_vanguardist
-				}			
+				}
 			}
 		}
 	}
-
-	ai_enact_weight_modifier = { #Petitions
+	ai_enact_weight_modifier = {
+		#Petitions
 		value = 0
-		
 		if = {
-			limit = { 
+			limit = {
 				has_journal_entry = je_government_petition
 				has_variable = desired_law_var
-                scope:law = var:desired_law_var
+				scope:law = var:desired_law_var
 			}
 			add = 750
 		}

--- a/common/laws/00_economic_system.txt
+++ b/common/laws/00_economic_system.txt
@@ -382,8 +382,8 @@ law_laissez_faire = {
 	}
 	modifier = {
 		country_loan_interest_rate_mult = -0.15
-		state_shopkeepers_investment_pool_efficiency_mult = 0.5
-		state_capitalists_investment_pool_efficiency_mult = 0.3
+		state_shopkeepers_investment_pool_efficiency_mult = 0.75
+		state_capitalists_investment_pool_efficiency_mult = 0.25
 		interest_group_ig_industrialists_pol_str_mult = 0.25
 		country_trade_route_competitiveness_mult = 0.1
 		country_private_construction_allocation_mult = 0.75

--- a/common/laws/00_economic_system.txt
+++ b/common/laws/00_economic_system.txt
@@ -305,7 +305,7 @@ law_industry_banned = {
 		}
 	}
 	modifier = {
-		building_group_bg_agriculture_throughput_mult = 0.15
+		building_group_bg_agriculture_throughput_mult = 0.20
 		state_expected_sol_mult = -0.1
 		interest_group_ig_rural_folk_pol_str_mult = 0.5
 		state_farmers_investment_pool_efficiency_mult = 1

--- a/common/laws/00_migration.txt
+++ b/common/laws/00_migration.txt
@@ -1,24 +1,21 @@
 ﻿law_no_migration_controls = {
 	group = lawgroup_migration
 	icon = "gfx/interface/icons/law_icons/no_migration_controls.dds"
-	
 	progressiveness = 50
-	
 	possible_political_movements = {
 		law_migration_controls
-	}	
+	}
 	pop_support = {
 		value = 0
 	}
-
-	ai_enact_weight_modifier = { #Petitions
+	ai_enact_weight_modifier = {
+		#Petitions
 		value = 0
-		
 		if = {
-			limit = { 
+			limit = {
 				has_journal_entry = je_government_petition
 				has_variable = desired_law_var
-                scope:law = var:desired_law_var
+				scope:law = var:desired_law_var
 			}
 			add = 750
 		}
@@ -28,28 +25,24 @@
 law_migration_controls = {
 	group = lawgroup_migration
 	icon = "gfx/interface/icons/law_icons/migration_controls.dds"
-	
 	modifier = {
-		country_disallow_discriminated_migration = yes	
+		country_disallow_discriminated_migration = yes
 	}
-	
 	progressiveness = 0
-	
 	possible_political_movements = {
 		law_no_migration_controls
 		law_closed_borders
 	}
-
 	pop_support = {
 		value = 0
 		add = {
 			desc = "POP_UNEMPLOYED_STATE"
 			if = {
-				limit = { 
-					owner = { 
-						NOT = { 
+				limit = {
+					owner = {
+						NOT = {
 							has_law = law_type:law_closed_borders
-						} 
+						}
 					}
 					state = {
 						state_unemployment_rate >= 0.1
@@ -59,10 +52,10 @@ law_migration_controls = {
 			}
 			if = {
 				limit = {
-					owner = { 
-						NOT = { 
+					owner = {
+						NOT = {
 							has_law = law_type:law_closed_borders
-						} 
+						}
 					}
 					state = {
 						state_unemployment_rate >= 0.2
@@ -71,11 +64,11 @@ law_migration_controls = {
 				value = 0.1
 			}
 			if = {
-				limit = { 
-					owner = { 
-						NOT = { 
+				limit = {
+					owner = {
+						NOT = {
 							has_law = law_type:law_closed_borders
-						} 
+						}
 					}
 					state = {
 						state_unemployment_rate >= 0.3
@@ -85,10 +78,10 @@ law_migration_controls = {
 			}
 			if = {
 				limit = {
-					owner = { 
-						NOT = { 
+					owner = {
+						NOT = {
 							has_law = law_type:law_closed_borders
-						} 
+						}
 					}
 					state = {
 						state_unemployment_rate >= 0.4
@@ -98,82 +91,10 @@ law_migration_controls = {
 			}
 			if = {
 				limit = {
-					owner = { 
-						NOT = { 
+					owner = {
+						NOT = {
 							has_law = law_type:law_closed_borders
-						} 
-					}
-					state = {
-						state_unemployment_rate >= 0.5
-					}
-				}
-				value = 0.1
-			}
-		}	
-	}
-
-	pop_support = {
-		value = 0
-		add = {
-			desc = "POP_LOWER_STRATA"
-			if = {
-				limit = { 
-					owner = { 
-						NOT = { 
-							has_law = law_type:law_closed_borders
-						} 
-					}
-					state = {
-						state_unemployment_rate >= 0.1
-					}
-				}
-				value = 0.1
-			}
-			if = {
-				limit = {
-					owner = { 
-						NOT = { 
-							has_law = law_type:law_closed_borders
-						} 
-					}
-					state = {
-						state_unemployment_rate >= 0.2
-					}
-				}
-				value = 0.1
-			}
-			if = {
-				limit = { 
-					owner = { 
-						NOT = { 
-							has_law = law_type:law_closed_borders
-						} 
-					}
-					state = {
-						state_unemployment_rate >= 0.3
-					}
-				}
-				value = 0.1
-			}
-			if = {
-				limit = {
-					owner = { 
-						NOT = { 
-							has_law = law_type:law_closed_borders
-						} 
-					}
-					state = {
-						state_unemployment_rate >= 0.4
-					}
-				}
-				value = 0.1
-			}
-			if = {
-				limit = {
-					owner = { 
-						NOT = { 
-							has_law = law_type:law_closed_borders
-						} 
+						}
 					}
 					state = {
 						state_unemployment_rate >= 0.5
@@ -183,15 +104,85 @@ law_migration_controls = {
 			}
 		}
 	}
-
-	ai_enact_weight_modifier = { #Petitions
+	pop_support = {
 		value = 0
-		
+		add = {
+			desc = "POP_LOWER_STRATA"
+			if = {
+				limit = {
+					owner = {
+						NOT = {
+							has_law = law_type:law_closed_borders
+						}
+					}
+					state = {
+						state_unemployment_rate >= 0.1
+					}
+				}
+				value = 0.1
+			}
+			if = {
+				limit = {
+					owner = {
+						NOT = {
+							has_law = law_type:law_closed_borders
+						}
+					}
+					state = {
+						state_unemployment_rate >= 0.2
+					}
+				}
+				value = 0.1
+			}
+			if = {
+				limit = {
+					owner = {
+						NOT = {
+							has_law = law_type:law_closed_borders
+						}
+					}
+					state = {
+						state_unemployment_rate >= 0.3
+					}
+				}
+				value = 0.1
+			}
+			if = {
+				limit = {
+					owner = {
+						NOT = {
+							has_law = law_type:law_closed_borders
+						}
+					}
+					state = {
+						state_unemployment_rate >= 0.4
+					}
+				}
+				value = 0.1
+			}
+			if = {
+				limit = {
+					owner = {
+						NOT = {
+							has_law = law_type:law_closed_borders
+						}
+					}
+					state = {
+						state_unemployment_rate >= 0.5
+					}
+				}
+				value = 0.1
+			}
+		}
+	}
+	ai_enact_weight_modifier = {
+		#Petitions
+		value = 0
 		if = {
-			limit = { 
+			limit = {
 				has_journal_entry = je_government_petition
 				has_variable = desired_law_var
-                scope:law = var:desired_law_var
+				scope:law = var:desired_law_var
 			}
 			add = 750
 		}
@@ -201,24 +192,20 @@ law_migration_controls = {
 law_closed_borders = {
 	group = lawgroup_migration
 	icon = "gfx/interface/icons/law_icons/closed_borders.dds"
-
 	modifier = {
 		country_disallow_migration = yes
 		country_disallow_agitator_invites = yes
 	}
-	
 	progressiveness = -50
-	
 	possible_political_movements = {
 		law_closed_borders
 	}
-
 	pop_support = {
 		value = 0
 		add = {
 			desc = "POP_UNEMPLOYED_STATE"
 			if = {
-				limit = { 
+				limit = {
 					state = {
 						state_unemployment_rate >= 0.1
 					}
@@ -234,54 +221,7 @@ law_closed_borders = {
 				value = 0.1
 			}
 			if = {
-				limit = { 
-					state = {
-						state_unemployment_rate >= 0.3
-					}
-				}
-				value = 0.1
-			}
-			if = {
 				limit = {
-					state = {
-						state_unemployment_rate >= 0.4
-					}
-				}
-				value = 0.1
-			}
-			if = {
-				limit = {
-					state = {
-						state_unemployment_rate >= 0.5
-					}
-				}
-				value = 0.1
-			}
-		}	
-	}
-
-	pop_support = {
-		value = 0
-		add = {
-			desc = "POP_LOWER_STRATA"
-			if = {
-				limit = { 
-					state = {
-						state_unemployment_rate >= 0.1
-					}
-				}
-				value = 0.1
-			}
-			if = {
-				limit = {
-					state = {
-						state_unemployment_rate >= 0.2
-					}
-				}
-				value = 0.1
-			}
-			if = {
-				limit = { 
 					state = {
 						state_unemployment_rate >= 0.3
 					}
@@ -306,15 +246,60 @@ law_closed_borders = {
 			}
 		}
 	}
-
-	ai_enact_weight_modifier = { #Petitions
+	pop_support = {
 		value = 0
-		
+		add = {
+			desc = "POP_LOWER_STRATA"
+			if = {
+				limit = {
+					state = {
+						state_unemployment_rate >= 0.1
+					}
+				}
+				value = 0.1
+			}
+			if = {
+				limit = {
+					state = {
+						state_unemployment_rate >= 0.2
+					}
+				}
+				value = 0.1
+			}
+			if = {
+				limit = {
+					state = {
+						state_unemployment_rate >= 0.3
+					}
+				}
+				value = 0.1
+			}
+			if = {
+				limit = {
+					state = {
+						state_unemployment_rate >= 0.4
+					}
+				}
+				value = 0.1
+			}
+			if = {
+				limit = {
+					state = {
+						state_unemployment_rate >= 0.5
+					}
+				}
+				value = 0.1
+			}
+		}
+	}
+	ai_enact_weight_modifier = {
+		#Petitions
+		value = 0
 		if = {
-			limit = { 
+			limit = {
 				has_journal_entry = je_government_petition
 				has_variable = desired_law_var
-                scope:law = var:desired_law_var
+				scope:law = var:desired_law_var
 			}
 			add = 750
 		}

--- a/common/laws/00_migration.txt
+++ b/common/laws/00_migration.txt
@@ -1,0 +1,322 @@
+﻿law_no_migration_controls = {
+	group = lawgroup_migration
+	icon = "gfx/interface/icons/law_icons/no_migration_controls.dds"
+	
+	progressiveness = 50
+	
+	possible_political_movements = {
+		law_migration_controls
+	}	
+	pop_support = {
+		value = 0
+	}
+
+	ai_enact_weight_modifier = { #Petitions
+		value = 0
+		
+		if = {
+			limit = { 
+				has_journal_entry = je_government_petition
+				has_variable = desired_law_var
+                scope:law = var:desired_law_var
+			}
+			add = 750
+		}
+	}
+}
+
+law_migration_controls = {
+	group = lawgroup_migration
+	icon = "gfx/interface/icons/law_icons/migration_controls.dds"
+	
+	modifier = {
+		country_disallow_discriminated_migration = yes	
+	}
+	
+	progressiveness = 0
+	
+	possible_political_movements = {
+		law_no_migration_controls
+		law_closed_borders
+	}
+
+	pop_support = {
+		value = 0
+		add = {
+			desc = "POP_UNEMPLOYED_STATE"
+			if = {
+				limit = { 
+					owner = { 
+						NOT = { 
+							has_law = law_type:law_closed_borders
+						} 
+					}
+					state = {
+						state_unemployment_rate >= 0.1
+					}
+				}
+				value = 0.1
+			}
+			if = {
+				limit = {
+					owner = { 
+						NOT = { 
+							has_law = law_type:law_closed_borders
+						} 
+					}
+					state = {
+						state_unemployment_rate >= 0.2
+					}
+				}
+				value = 0.1
+			}
+			if = {
+				limit = { 
+					owner = { 
+						NOT = { 
+							has_law = law_type:law_closed_borders
+						} 
+					}
+					state = {
+						state_unemployment_rate >= 0.3
+					}
+				}
+				value = 0.1
+			}
+			if = {
+				limit = {
+					owner = { 
+						NOT = { 
+							has_law = law_type:law_closed_borders
+						} 
+					}
+					state = {
+						state_unemployment_rate >= 0.4
+					}
+				}
+				value = 0.1
+			}
+			if = {
+				limit = {
+					owner = { 
+						NOT = { 
+							has_law = law_type:law_closed_borders
+						} 
+					}
+					state = {
+						state_unemployment_rate >= 0.5
+					}
+				}
+				value = 0.1
+			}
+		}	
+	}
+
+	pop_support = {
+		value = 0
+		add = {
+			desc = "POP_LOWER_STRATA"
+			if = {
+				limit = { 
+					owner = { 
+						NOT = { 
+							has_law = law_type:law_closed_borders
+						} 
+					}
+					state = {
+						state_unemployment_rate >= 0.1
+					}
+				}
+				value = 0.1
+			}
+			if = {
+				limit = {
+					owner = { 
+						NOT = { 
+							has_law = law_type:law_closed_borders
+						} 
+					}
+					state = {
+						state_unemployment_rate >= 0.2
+					}
+				}
+				value = 0.1
+			}
+			if = {
+				limit = { 
+					owner = { 
+						NOT = { 
+							has_law = law_type:law_closed_borders
+						} 
+					}
+					state = {
+						state_unemployment_rate >= 0.3
+					}
+				}
+				value = 0.1
+			}
+			if = {
+				limit = {
+					owner = { 
+						NOT = { 
+							has_law = law_type:law_closed_borders
+						} 
+					}
+					state = {
+						state_unemployment_rate >= 0.4
+					}
+				}
+				value = 0.1
+			}
+			if = {
+				limit = {
+					owner = { 
+						NOT = { 
+							has_law = law_type:law_closed_borders
+						} 
+					}
+					state = {
+						state_unemployment_rate >= 0.5
+					}
+				}
+				value = 0.1
+			}
+		}
+	}
+
+	ai_enact_weight_modifier = { #Petitions
+		value = 0
+		
+		if = {
+			limit = { 
+				has_journal_entry = je_government_petition
+				has_variable = desired_law_var
+                scope:law = var:desired_law_var
+			}
+			add = 750
+		}
+	}
+}
+
+law_closed_borders = {
+	group = lawgroup_migration
+	icon = "gfx/interface/icons/law_icons/closed_borders.dds"
+
+	modifier = {
+		country_disallow_migration = yes
+		country_disallow_agitator_invites = yes
+	}
+	
+	progressiveness = -50
+	
+	possible_political_movements = {
+		law_closed_borders
+	}
+
+	pop_support = {
+		value = 0
+		add = {
+			desc = "POP_UNEMPLOYED_STATE"
+			if = {
+				limit = { 
+					state = {
+						state_unemployment_rate >= 0.1
+					}
+				}
+				value = 0.1
+			}
+			if = {
+				limit = {
+					state = {
+						state_unemployment_rate >= 0.2
+					}
+				}
+				value = 0.1
+			}
+			if = {
+				limit = { 
+					state = {
+						state_unemployment_rate >= 0.3
+					}
+				}
+				value = 0.1
+			}
+			if = {
+				limit = {
+					state = {
+						state_unemployment_rate >= 0.4
+					}
+				}
+				value = 0.1
+			}
+			if = {
+				limit = {
+					state = {
+						state_unemployment_rate >= 0.5
+					}
+				}
+				value = 0.1
+			}
+		}	
+	}
+
+	pop_support = {
+		value = 0
+		add = {
+			desc = "POP_LOWER_STRATA"
+			if = {
+				limit = { 
+					state = {
+						state_unemployment_rate >= 0.1
+					}
+				}
+				value = 0.1
+			}
+			if = {
+				limit = {
+					state = {
+						state_unemployment_rate >= 0.2
+					}
+				}
+				value = 0.1
+			}
+			if = {
+				limit = { 
+					state = {
+						state_unemployment_rate >= 0.3
+					}
+				}
+				value = 0.1
+			}
+			if = {
+				limit = {
+					state = {
+						state_unemployment_rate >= 0.4
+					}
+				}
+				value = 0.1
+			}
+			if = {
+				limit = {
+					state = {
+						state_unemployment_rate >= 0.5
+					}
+				}
+				value = 0.1
+			}
+		}
+	}
+
+	ai_enact_weight_modifier = { #Petitions
+		value = 0
+		
+		if = {
+			limit = { 
+				has_journal_entry = je_government_petition
+				has_variable = desired_law_var
+                scope:law = var:desired_law_var
+			}
+			add = 750
+		}
+	}
+}

--- a/common/laws/00_migration.txt
+++ b/common/laws/00_migration.txt
@@ -1,6 +1,11 @@
 ﻿law_no_migration_controls = {
 	group = lawgroup_migration
 	icon = "gfx/interface/icons/law_icons/no_migration_controls.dds"
+	modifier = {
+		country_disallow_discriminated_migration = yes
+		country_authority_mult = -0.05
+		country_tech_spread_mult = 0.05
+	}
 	progressiveness = 50
 	possible_political_movements = {
 		law_migration_controls
@@ -27,6 +32,8 @@ law_migration_controls = {
 	icon = "gfx/interface/icons/law_icons/migration_controls.dds"
 	modifier = {
 		country_disallow_discriminated_migration = yes
+		country_authority_mult = 0.05
+		state_tax_capacity_mult = 0.025
 	}
 	progressiveness = 0
 	possible_political_movements = {
@@ -195,7 +202,11 @@ law_closed_borders = {
 	modifier = {
 		country_disallow_migration = yes
 		country_disallow_agitator_invites = yes
-	}
+		country_legitimacy_base_add = 5
+		country_authority_mult = 0.25
+		state_tax_capacity_mult = 0.10
+		country_tech_spread_mult = -0.15
+}
 	progressiveness = -50
 	possible_political_movements = {
 		law_closed_borders

--- a/common/laws/00_slavery.txt
+++ b/common/laws/00_slavery.txt
@@ -1,124 +1,6 @@
 ﻿# group = this is the law_group a law belongs to
 # icon = graphical icon shown in-game
 # modifier = {} modifier on country for having adopted this law
-law_debt_slavery = {
-	group = lawgroup_slavery
-	progressiveness = 0
-	icon = "gfx/interface/icons/law_icons/debt_slavery.dds"
-	disallowing_laws = {
-		law_multicultural
-	}
-	on_activate = {
-		ig:ig_landowners ?= {
-			if = {
-				limit = {
-					NOT = {
-						has_ideology = ideology:ideology_pro_slavery
-					}
-				}
-				add_ideology = ideology_pro_slavery
-			}
-		}
-		ig:ig_industrialists ?= { 
-			if = {
-				limit = {
-					NOT = { has_ideology = ideology:ideology_pro_slavery }
-				}			
-				add_ideology = ideology_pro_slavery 
-			}
-		}
-	}
-	modifier = {
-		interest_group_ig_industrialists_pol_str_mult = 0.15
-
-	}
-	pop_support = {
-		value = 0
-		add = {
-			desc = "POP_SLAVES"
-			if = {
-				limit = {
-					is_pop_type = slaves
-				}
-				value = 1
-			}
-		}
-		add = {
-			desc = "POP_ACADEMICS"
-			if = {
-				limit = {
-					is_pop_type = academics
-				}
-				value = 0.1
-			}
-		}
-		add = {
-			desc = "POP_CLERGYMEN"
-			if = {
-				limit = {
-					is_pop_type = clergymen
-				}
-				value = 0.05
-			}
-		}
-	}
-	possible_political_movements = {
-		law_slavery_banned
-		law_legacy_slavery
-	}
-	# AI should never enact debt slavery
-	ai_will_do = {
-		always = no
-	}
-	revolution_state_weight = {
-		value = 1
-		if = {
-			limit = {
-				is_slave_state = no
-				NOT = {
-					has_variable = former_slave_state
-				}
-			}
-			if = {
-				limit = {
-					owner = {
-						# special logic for ACW to try and force a historical split of states 					
-						has_journal_entry = je_acw_countdown
-						OR = {
-							has_law = law_type:law_legacy_slavery
-							has_variable = slavery_recently_abolished
-						}
-						any_scope_state = {
-							OR = {
-								is_slave_state = yes
-								has_variable = former_slave_state
-							}
-						}
-					}
-				}
-				multiply = 0
-			}
-			else = {
-				multiply = 0.25
-			}
-		}
-	}
-	ai_enact_weight_modifier = {
-		#Petitions
-		value = 0
-		if = {
-			limit = {
-				has_journal_entry = je_government_petition
-				has_variable = desired_law_var
-				scope:law = var:desired_law_var
-			}
-			add = 750
-		}
-	}
-}
-# group = this is the law_group a law belongs to
-# icon = graphical icon shown in-game
-# modifier = {} modifier on country for having adopted this law
 
 law_slavery_banned = {
 	group = lawgroup_slavery
@@ -214,6 +96,128 @@ law_slavery_banned = {
 			  multiply = 0.25
 		   }	
 		}	
+	}
+
+	ai_enact_weight_modifier = { #Petitions
+		value = 0
+		
+		if = {
+			limit = { 
+				has_journal_entry = je_government_petition
+				has_variable = desired_law_var
+                scope:law = var:desired_law_var
+			}
+			add = 750
+		}
+	}
+}
+
+law_debt_slavery = {
+	group = lawgroup_slavery
+	
+	progressiveness = 0
+	
+	icon = "gfx/interface/icons/law_icons/debt_slavery.dds"
+	
+	disallowing_laws = {
+		law_multicultural
+	}
+
+	on_activate = {
+		ig:ig_landowners ?= { 
+			if = {
+				limit = {
+					NOT = { has_ideology = ideology:ideology_pro_slavery }
+				}			
+				add_ideology = ideology_pro_slavery 
+			}
+		}
+		ig:ig_industrialists ?= { 
+			if = {
+				limit = {
+					NOT = { has_ideology = ideology:ideology_pro_slavery }
+				}			
+				add_ideology = ideology_pro_slavery 
+			}
+		}
+	}
+	
+	modifier = {
+		interest_group_ig_industrialists_pol_str_mult = 0.25
+
+	}
+	
+	pop_support = {
+		value = 0
+		
+		add = {
+			desc = "POP_SLAVES"
+			if = {
+				limit = { 
+					is_pop_type = slaves
+				}
+				value = 1
+			}
+		}	
+		add = {
+			desc = "POP_ACADEMICS"
+			if = {
+				limit = {
+					is_pop_type = academics
+				}
+				value = 0.1
+			}
+		}
+		add = {
+			desc = "POP_CLERGYMEN"
+			if = {
+				limit = {
+					is_pop_type = clergymen
+				}
+				value = 0.05
+			}
+		}
+	}
+	
+	possible_political_movements = {
+		law_slavery_banned
+		law_legacy_slavery
+	}
+	
+	# AI should never enact debt slavery
+	ai_will_do = {
+		always = no
+	}
+	
+	revolution_state_weight = {
+		value = 1
+		if = {
+		   limit = { 
+			  is_slave_state = no 
+			  NOT = { has_variable = former_slave_state }
+		   }	
+		   if = {
+		      limit = { 
+				owner = { # special logic for ACW to try and force a historical split of states 					
+					has_journal_entry = je_acw_countdown
+					OR = {
+						has_law = law_type:law_legacy_slavery
+						has_variable = slavery_recently_abolished
+					}
+					any_scope_state = {
+						OR = {
+						   is_slave_state = yes 
+						   has_variable = former_slave_state			
+						}				
+					}					
+				} 
+			  }	  
+			  multiply = 0.0
+		   }
+		   else = {
+			  multiply = 0.25
+		   }
+		}
 	}
 
 	ai_enact_weight_modifier = { #Petitions

--- a/common/laws/00_slavery.txt
+++ b/common/laws/00_slavery.txt
@@ -143,7 +143,7 @@ law_debt_slavery = {
 	}
 	
 	modifier = {
-		interest_group_ig_industrialists_pol_str_mult = 0.25
+		interest_group_ig_industrialists_pol_str_mult = 0.10
 
 	}
 	

--- a/common/laws/00_slavery.txt
+++ b/common/laws/00_slavery.txt
@@ -1,44 +1,38 @@
 ﻿# group = this is the law_group a law belongs to
 # icon = graphical icon shown in-game
 # modifier = {} modifier on country for having adopted this law
-
 law_debt_slavery = {
 	group = lawgroup_slavery
-	
 	progressiveness = 0
-	
 	icon = "gfx/interface/icons/law_icons/debt_slavery.dds"
-	
 	disallowing_laws = {
 		law_multicultural
 	}
-
 	on_activate = {
-		ig:ig_landowners ?= { 
+		ig:ig_landowners ?= {
 			if = {
 				limit = {
-					NOT = { has_ideology = ideology:ideology_pro_slavery }
-				}			
-				add_ideology = ideology_pro_slavery 
+					NOT = {
+						has_ideology = ideology:ideology_pro_slavery
+					}
+				}
+				add_ideology = ideology_pro_slavery
 			}
 		}
 	}
-	
 	modifier = {
 	}
-	
 	pop_support = {
 		value = 0
-		
 		add = {
 			desc = "POP_SLAVES"
 			if = {
-				limit = { 
+				limit = {
 					is_pop_type = slaves
 				}
 				value = 1
 			}
-		}	
+		}
 		add = {
 			desc = "POP_ACADEMICS"
 			if = {
@@ -58,56 +52,55 @@ law_debt_slavery = {
 			}
 		}
 	}
-	
 	possible_political_movements = {
 		law_slavery_banned
 		law_legacy_slavery
 	}
-	
 	# AI should never enact debt slavery
 	ai_will_do = {
 		always = no
 	}
-	
 	revolution_state_weight = {
 		value = 1
 		if = {
-		   limit = { 
-			  is_slave_state = no 
-			  NOT = { has_variable = former_slave_state }
-		   }	
-		   if = {
-		      limit = { 
-				owner = { # special logic for ACW to try and force a historical split of states 					
-					has_journal_entry = je_acw_countdown
-					OR = {
-						has_law = law_type:law_legacy_slavery
-						has_variable = slavery_recently_abolished
-					}
-					any_scope_state = {
+			limit = {
+				is_slave_state = no
+				NOT = {
+					has_variable = former_slave_state
+				}
+			}
+			if = {
+				limit = {
+					owner = {
+						# special logic for ACW to try and force a historical split of states 					
+						has_journal_entry = je_acw_countdown
 						OR = {
-						   is_slave_state = yes 
-						   has_variable = former_slave_state			
-						}				
-					}					
-				} 
-			  }	  
-			  multiply = 0.0
-		   }
-		   else = {
-			  multiply = 0.25
-		   }
+							has_law = law_type:law_legacy_slavery
+							has_variable = slavery_recently_abolished
+						}
+						any_scope_state = {
+							OR = {
+								is_slave_state = yes
+								has_variable = former_slave_state
+							}
+						}
+					}
+				}
+				multiply = 0
+			}
+			else = {
+				multiply = 0.25
+			}
 		}
 	}
-
-	ai_enact_weight_modifier = { #Petitions
+	ai_enact_weight_modifier = {
+		#Petitions
 		value = 0
-		
 		if = {
-			limit = { 
+			limit = {
 				has_journal_entry = je_government_petition
 				has_variable = desired_law_var
-                scope:law = var:desired_law_var
+				scope:law = var:desired_law_var
 			}
 			add = 750
 		}

--- a/common/laws/00_slavery.txt
+++ b/common/laws/00_slavery.txt
@@ -19,8 +19,18 @@ law_debt_slavery = {
 				add_ideology = ideology_pro_slavery
 			}
 		}
+		ig:ig_industrialists ?= { 
+			if = {
+				limit = {
+					NOT = { has_ideology = ideology:ideology_pro_slavery }
+				}			
+				add_ideology = ideology_pro_slavery 
+			}
+		}
 	}
 	modifier = {
+		interest_group_ig_industrialists_pol_str_mult = 0.15
+
 	}
 	pop_support = {
 		value = 0
@@ -101,6 +111,368 @@ law_debt_slavery = {
 				has_journal_entry = je_government_petition
 				has_variable = desired_law_var
 				scope:law = var:desired_law_var
+			}
+			add = 750
+		}
+	}
+}
+# group = this is the law_group a law belongs to
+# icon = graphical icon shown in-game
+# modifier = {} modifier on country for having adopted this law
+
+law_slavery_banned = {
+	group = lawgroup_slavery
+	
+	progressiveness = 100
+	
+	icon = "gfx/interface/icons/law_icons/slavery_banned.dds"
+	
+	on_activate = {
+		set_variable = {
+			name = slavery_recently_abolished
+			value = yes
+			days = 1825
+		}
+		every_scope_state = {
+			limit = { 
+				any_scope_pop = {
+					is_pop_type = slaves
+				}
+			}
+			set_variable = {
+				name = former_slave_state
+				value = yes
+				days = 1825
+			}			
+		}
+		custom_tooltip = {
+			text = liberate_slaves_tt
+			liberate_slaves = yes
+		}		
+	}
+	
+	modifier = {
+	}
+	
+	pop_support = {
+		value = 0
+		
+		add = {
+			desc = "POP_SLAVES"
+			if = {
+				limit = { 
+					is_pop_type = slaves
+				}
+				value = 1
+			}
+		}
+		add = {
+			desc = "POP_ACADEMICS"
+			if = {
+				limit = {
+					is_pop_type = academics
+				}
+				value = 0.1
+			}
+		}
+		add = {
+			desc = "POP_CLERGYMEN"
+			if = {
+				limit = {
+					is_pop_type = clergymen
+				}
+				value = 0.05
+			}
+		}
+	}
+	
+	revolution_state_weight = {
+		value = 1
+		if = {
+		   limit = { 
+			OR = {
+			   is_slave_state = yes 
+			   has_variable = former_slave_state			
+			}
+		   }
+		   if = {
+		      limit = { 
+				owner = { # special logic for ACW to try and force a historical split of states
+					OR = {
+						has_law = law_type:law_legacy_slavery
+						has_variable = slavery_recently_abolished
+					}				
+					any_scope_state = {
+						is_slave_state = no 
+						NOT = { has_variable = former_slave_state }					
+					}
+				}	
+			 }
+			  multiply = 0.0
+		   }
+		   else = {
+			  multiply = 0.25
+		   }	
+		}	
+	}
+
+	ai_enact_weight_modifier = { #Petitions
+		value = 0
+		
+		if = {
+			limit = { 
+				has_journal_entry = je_government_petition
+				has_variable = desired_law_var
+                scope:law = var:desired_law_var
+			}
+			add = 750
+		}
+	}
+}
+
+law_slave_trade = {
+	group = lawgroup_slavery
+	
+	progressiveness = 0
+	
+	icon = "gfx/interface/icons/law_icons/slave_trade.dds"
+	
+	disallowing_laws = {
+		law_cultural_exclusion
+		law_multicultural
+	}
+	
+	on_activate = {
+		if = {
+			limit = { has_variable = slavery_recently_abolished }
+			custom_tooltip = {
+				text = enslave_discriminated_farm_workers_tt
+				every_scope_state = {
+					limit = { has_variable = former_slave_state }
+					enslave_discriminated_farm_workers = yes
+				}	
+			}	
+			remove_variable = slavery_recently_abolished
+			every_scope_state = {
+				remove_variable = former_slave_state
+			}			
+		}
+
+		ig:ig_landowners ?= { 
+			if = {
+				limit = {
+					NOT = { has_ideology = ideology:ideology_pro_slavery }
+				}			
+				add_ideology = ideology_pro_slavery 
+			}
+		}
+	}
+	
+	modifier = {
+		interest_group_ig_landowners_pol_str_mult = 0.5
+	}
+	
+	possible_political_movements = {
+		law_slavery_banned
+		law_legacy_slavery
+	}
+
+	pop_support = {
+		value = 0
+		
+		add = {
+			desc = "POP_ARISTOCRATS"
+			if = {
+				limit = { 
+					is_pop_type = aristocrats
+				}
+				value = 0.1
+			}
+		}
+	}
+	
+	ai_will_do = {
+		exists = ruler
+		ruler = {
+			has_ideology = ideology:ideology_slaver
+		}
+	}
+	
+	revolution_state_weight = {
+		value = 1
+		if = {
+		   limit = { 
+			  is_slave_state = no 
+			  NOT = { has_variable = former_slave_state }
+		   }	
+		   if = {
+		      limit = { 
+				owner = { # special logic for ACW to try and force a historical split of states					
+					has_journal_entry = je_acw_countdown
+					OR = {
+						has_law = law_type:law_legacy_slavery
+						has_variable = slavery_recently_abolished
+					}
+					any_scope_state = {
+						OR = {
+						   is_slave_state = yes 
+						   has_variable = former_slave_state			
+						}				
+					}						
+				} 
+			  }	  
+			  multiply = 0.0
+		   }
+		   else = {
+			  multiply = 0.25
+		   }
+		}
+	}
+
+	ai_enact_weight_modifier = { #Petitions
+		value = 0
+		
+		if = {
+			limit = { 
+				has_journal_entry = je_government_petition
+				has_variable = desired_law_var
+                scope:law = var:desired_law_var
+			}
+			add = 750
+		}
+	}
+}
+
+law_legacy_slavery = {
+	group = lawgroup_slavery
+	
+	progressiveness = 50
+	
+	icon = "gfx/interface/icons/law_icons/legacy_slavery.dds"
+
+	# no need to add disallowing_laws here since it can only be enacted from Slave Trade
+	
+	unlocking_laws = {
+		law_slave_trade
+	}
+	
+	on_activate = {
+		if = {
+			limit = { has_variable = slavery_recently_abolished }
+			custom_tooltip = {
+				text = enslave_discriminated_farm_workers_tt
+				every_scope_state = {
+					limit = { has_variable = former_slave_state }
+					enslave_discriminated_farm_workers = yes
+				}			
+			}
+			remove_variable = slavery_recently_abolished
+			every_scope_state = {
+				remove_variable = former_slave_state
+			}
+		}
+
+		ig:ig_landowners ?= { 
+			if = {
+				limit = {
+					NOT = { has_ideology = ideology:ideology_pro_slavery }
+				}			
+				add_ideology = ideology_pro_slavery 
+			}
+		}
+	}	
+	
+	modifier = {
+		interest_group_ig_landowners_pol_str_mult = 0.25
+	}
+	
+	possible_political_movements = {
+		law_slavery_banned
+	}
+
+	pop_support = {
+		value = 0
+		add = {
+			desc = "POP_ACADEMICS"
+			if = {
+				limit = {
+					is_pop_type = academics
+				}
+				value = 0.1
+			}
+		}
+		add = {
+			desc = "POP_CLERGYMEN"
+			if = {
+				limit = {
+					is_pop_type = clergymen
+				}
+				value = 0.05
+			}
+		}
+	}
+	
+	pop_support = {
+		value = 0
+		add = {
+			desc = "POP_ACADEMICS"
+			if = {
+				limit = {
+					is_pop_type = academics
+				}
+				value = 0.1
+			}
+		}
+		add = {
+			desc = "POP_CLERGYMEN"
+			if = {
+				limit = {
+					is_pop_type = clergymen
+				}
+				value = 0.05
+			}
+		}
+	}
+
+	revolution_state_weight = {
+		value = 1
+		if = {
+		   limit = { 
+			  is_slave_state = no 
+			  NOT = { has_variable = former_slave_state }
+		   }	
+		   if = {
+		      limit = { 
+				owner = { # special logic for ACW to try and force a historical split of states					
+					has_journal_entry = je_acw_countdown
+					OR = {
+						has_law = law_type:law_legacy_slavery
+						has_variable = slavery_recently_abolished
+					}
+					any_scope_state = {
+						OR = {
+						   is_slave_state = yes 
+						   has_variable = former_slave_state			
+						}				
+					}						
+				} 
+			  } 
+			  multiply = 0.0
+		   }
+		   else = {
+			  multiply = 0.25
+		   }
+		}
+	}
+
+	ai_enact_weight_modifier = { #Petitions
+		value = 0
+		
+		if = {
+			limit = { 
+				has_journal_entry = je_government_petition
+				has_variable = desired_law_var
+                scope:law = var:desired_law_var
 			}
 			add = 750
 		}

--- a/common/laws/00_slavery.txt
+++ b/common/laws/00_slavery.txt
@@ -1,0 +1,115 @@
+﻿# group = this is the law_group a law belongs to
+# icon = graphical icon shown in-game
+# modifier = {} modifier on country for having adopted this law
+
+law_debt_slavery = {
+	group = lawgroup_slavery
+	
+	progressiveness = 0
+	
+	icon = "gfx/interface/icons/law_icons/debt_slavery.dds"
+	
+	disallowing_laws = {
+		law_multicultural
+	}
+
+	on_activate = {
+		ig:ig_landowners ?= { 
+			if = {
+				limit = {
+					NOT = { has_ideology = ideology:ideology_pro_slavery }
+				}			
+				add_ideology = ideology_pro_slavery 
+			}
+		}
+	}
+	
+	modifier = {
+	}
+	
+	pop_support = {
+		value = 0
+		
+		add = {
+			desc = "POP_SLAVES"
+			if = {
+				limit = { 
+					is_pop_type = slaves
+				}
+				value = 1
+			}
+		}	
+		add = {
+			desc = "POP_ACADEMICS"
+			if = {
+				limit = {
+					is_pop_type = academics
+				}
+				value = 0.1
+			}
+		}
+		add = {
+			desc = "POP_CLERGYMEN"
+			if = {
+				limit = {
+					is_pop_type = clergymen
+				}
+				value = 0.05
+			}
+		}
+	}
+	
+	possible_political_movements = {
+		law_slavery_banned
+		law_legacy_slavery
+	}
+	
+	# AI should never enact debt slavery
+	ai_will_do = {
+		always = no
+	}
+	
+	revolution_state_weight = {
+		value = 1
+		if = {
+		   limit = { 
+			  is_slave_state = no 
+			  NOT = { has_variable = former_slave_state }
+		   }	
+		   if = {
+		      limit = { 
+				owner = { # special logic for ACW to try and force a historical split of states 					
+					has_journal_entry = je_acw_countdown
+					OR = {
+						has_law = law_type:law_legacy_slavery
+						has_variable = slavery_recently_abolished
+					}
+					any_scope_state = {
+						OR = {
+						   is_slave_state = yes 
+						   has_variable = former_slave_state			
+						}				
+					}					
+				} 
+			  }	  
+			  multiply = 0.0
+		   }
+		   else = {
+			  multiply = 0.25
+		   }
+		}
+	}
+
+	ai_enact_weight_modifier = { #Petitions
+		value = 0
+		
+		if = {
+			limit = { 
+				has_journal_entry = je_government_petition
+				has_variable = desired_law_var
+                scope:law = var:desired_law_var
+			}
+			add = 750
+		}
+	}
+}


### PR DESCRIPTION
Contributes to #95. Changes Economic Systems to make them more differentiated on who contributes, adds penalties to socialist laws to reflect the international trade pariah aspect, and added some buffs/debuffs to better reflect each law.

For migration, added some benefits and detriments to each law, with Migration controls being the milquetoast "middle ground" that most nations will shoot for over time.

For slavery, added Pro-Slavery ideology to Industrialists to Debt Slavery to make it a stickier law than it used to be and create a struggle for nations with this law to remove it. It used to have 0 support and was easily removable for context.

@HiddeLekanne @Danarca ready for review