### PR TITLE
Congress event spam lessened

### DIFF
--- a/common/scripted_effects/imperia_vienna_congress_effects.txt
+++ b/common/scripted_effects/imperia_vienna_congress_effects.txt
@@ -716,11 +716,31 @@ congress_send_out_invitation = {
 				COUNTRY = this
 				STANCE = 1
 			}
-			trigger_event = {
-				# Start parade
-				id = congress_random_event.14
-				popup = yes
-				days = 35
+			random_list = {
+				10 = {
+					trigger_event = {
+						# Start parade
+						id = congress_random_event.14
+						popup = yes
+						days = 35
+					}
+				}
+				10 = {
+					trigger_event = {
+						# Start masked ball
+						id = congress_random_event.9
+						popup = yes
+						days = 35
+					}
+				}
+				10 = {
+					trigger_event = {
+						# Start Language vote
+						id = congress_random_event.23
+						popup = yes
+						days = 35
+					}
+				}
 			}
 		}
 		else_if = {

--- a/events/conference_events/imperia_vienna_congress_random_events.txt
+++ b/events/conference_events/imperia_vienna_congress_random_events.txt
@@ -2693,16 +2693,6 @@ congress_random_event.18 = {
 				remove_variable ?= chosen_budget_level
 			}
 			global_var:imperia_vienna_congress_session_initiator = {
-				trigger_event = {
-					# Masked Ball
-					id = congress_random_event.9
-					days = 30
-				}
-				trigger_event = {
-					# Choosing the official language of congress
-					id = congress_random_event.23
-					days = 7
-				}
 				random = {
 					chance = 5
 					trigger_event = {


### PR DESCRIPTION
Only 1 of the previously 3 guaranteed chains will now fire on start, chosen at random. The other ones will not fire that congress.

The chosen chain will spawn 35 days after the start of congress.
The chains are; the parade, the masked ball and the language vote.