### PR TITLE
Red scare slowdown fix

### DIFF
--- a/common/journal_entries/03_red_scare.txt
+++ b/common/journal_entries/03_red_scare.txt
@@ -46,7 +46,8 @@
 							}
 						}
 					}
-					any_country = {
+					any_in_global_list = {
+						variable = council_republics_list
 						has_diplomatic_relevance = root
 						has_law = law_type:law_council_republic
 					}
@@ -99,7 +100,8 @@
 	}
 	invalid = {
 		NOT = {
-			any_country = {
+			any_in_global_list = {
+				variable = council_republics_list
 				has_diplomatic_relevance = root
 				has_law = law_type:law_council_republic
 			}

--- a/common/journal_entries/03_red_scare.txt
+++ b/common/journal_entries/03_red_scare.txt
@@ -1,0 +1,116 @@
+﻿je_the_red_scare = {
+	icon = "gfx/interface/icons/event_icons/event_protest.dds"
+	group = je_group_crises
+	is_shown_when_inactive = {
+		# This variable is set globally once the tech is researched
+		has_global_variable = labor_movement_researched
+	}
+	possible = {
+		custom_tooltip = {
+			text = red_scare_unlock_tt
+			# Now checks if theres any valid countries in this list; its set in on_yearly_pulse_country
+			any_in_global_list = {
+				variable = council_republics_list
+				has_diplomatic_relevance = root
+				has_law = law_type:law_council_republic
+			}
+		}
+		NOT = {
+			has_law = law_type:law_council_republic
+		}
+	}
+	immediate = {
+		ordered_country = {
+			limit = {
+				has_diplomatic_relevance = root
+				has_law = law_type:law_council_republic
+			}
+			order_by = country_rank
+			save_scope_as = red_scare_target_nation
+		}
+		trigger_event = {
+			id = red_scare.1
+		}
+	}
+	on_weekly_pulse = {
+		effect = {
+			if = {
+				limit = {
+					OR = {
+						NOT = {
+							exists = scope:red_scare_target_nation
+						}
+						scope:red_scare_target_nation ?= {
+							NOT = {
+								has_law = law_type:law_council_republic
+							}
+						}
+					}
+					any_country = {
+						has_diplomatic_relevance = root
+						has_law = law_type:law_council_republic
+					}
+				}
+				ordered_country = {
+					limit = {
+						has_diplomatic_relevance = root
+						has_law = law_type:law_council_republic
+					}
+					order_by = country_rank
+					save_scope_as = red_scare_target_nation
+				}
+			}
+		}
+	}
+	on_monthly_pulse = {
+		random_events = {
+			300 = 0
+			10 = red_scare.2
+			10 = red_scare.3
+			10 = red_scare.4
+			10 = red_scare.5
+			10 = red_scare.6
+			10 = red_scare.7
+			10 = red_scare.8
+			10 = red_scare.9
+			10 = red_scare.10
+			10 = red_scare.11
+			10 = red_scare.12
+			10 = red_scare.14
+			10 = red_scare.15
+		}
+	}
+	fail = {
+		OR = {
+			has_law = law_type:law_council_republic
+			any_civil_war = {
+				this.political_movement ?= {
+					any_supporting_interest_group = {
+						law_stance = {
+							law = law_type:law_council_republic
+							value > neutral
+						}
+					}
+				}
+				is_civil_war_type = revolution
+				civil_war_progress > 0.75
+			}
+		}
+	}
+	invalid = {
+		NOT = {
+			any_country = {
+				has_diplomatic_relevance = root
+				has_law = law_type:law_council_republic
+			}
+		}
+	}
+	timeout = 3650
+	on_timeout = {
+		trigger_event = {
+			id = red_scare.20
+		}
+	}
+	weight = 1000
+	should_be_pinned_by_default = yes
+}

--- a/common/on_actions/imperia_index_on_actions.txt
+++ b/common/on_actions/imperia_index_on_actions.txt
@@ -28,6 +28,7 @@ on_monthly_pulse_state = {
 		on_imperia_monthly_pulse_state
 	}
 }
+
 # Root = Country
 # scope:target = Uprising country
 on_revolution_start = {
@@ -43,6 +44,13 @@ on_monthly_pulse_country = {
 		on_imperia_monthly_pulse_store_infamy
 		on_imperia_monthly_pulse_ai_congress_voting
 		on_imperia_monthly_pulse_ai_executive_decisions
+	}
+}
+
+# Root = Country
+on_half_yearly_pulse_country = {
+	on_actions = {
+		on_imperia_half_yearly_pulse_country
 	}
 }
 

--- a/common/on_actions/imperia_on_half_yearly_pulse.txt
+++ b/common/on_actions/imperia_on_half_yearly_pulse.txt
@@ -1,0 +1,22 @@
+﻿on_imperia_half_yearly_pulse_country = {
+	effect = {
+		# Resets the global list twice per year only
+		# Instead of [every_country -> every_country] x yearly
+		if = {
+			limit = {
+				has_global_highest_gdp = yes
+			}
+			clear_global_variable_list ?= council_republics_list
+			every_country = {
+				limit = {
+					has_law = law_type:law_council_republic
+					country_rank > rank_value:minor_power
+				}
+				add_to_global_variable_list = {
+					name = council_republics_list
+					target = THIS
+				}
+			}
+		}
+	}
+}

--- a/common/on_actions/imperia_on_half_yearly_pulse.txt
+++ b/common/on_actions/imperia_on_half_yearly_pulse.txt
@@ -5,6 +5,7 @@
 		if = {
 			limit = {
 				has_global_highest_gdp = yes
+				has_global_variable = labor_movement_researched
 			}
 			clear_global_variable_list ?= council_republics_list
 			every_country = {

--- a/common/technology/technologies/30_society.txt
+++ b/common/technology/technologies/30_society.txt
@@ -638,6 +638,9 @@ labor_movement = {
 		mass_communication
 		egalitarianism
 	}
+	on_researched = {
+		set_global_variable = labor_movement_researched
+	}
 	ai_weight = {
 		value = 1
 		if = {


### PR DESCRIPTION
*Extremely* lean, tested with 0ms in tests where there first was no labor_movement researched, and then even once it had it been researched.
Once a council republic popped up it averaged at 1.5ms over 300 ticks, with a max of 34ms on the `possible` section.
May want to give some sort of credit to this mod; https://steamcommunity.com/sharedfiles/filedetails/?id=3213294110 for the overall logic.

Although he *did* fuckup the on_actions, and I improved his logic in there.