### PR TITLE
True Neutrals can reduce autonomy/annex subjects

### DIFF
--- a/common/diplomatic_plays/00_diplomatic_plays.txt
+++ b/common/diplomatic_plays/00_diplomatic_plays.txt
@@ -182,7 +182,7 @@ dp_reduce_autonomy = {
 	texture = "gfx/interface/icons/war_goals/reduce_autonomy.dds"
 	
 	possible = {
-		imperia_aggressive_diplomatic_plays_permitted = yes
+		imperia_true_neutral_diplomatic_plays_permitted = yes
 		imperia_foreign_laws_permits_play = yes
 		scope:target_country = { is_subject = yes }
 	}
@@ -238,7 +238,7 @@ dp_annex_subject = {
 	texture = "gfx/interface/icons/war_goals/annex_country.dds"
 	possible = {
 		NOT = { is_country_type = decentralized }
-		imperia_aggressive_diplomatic_plays_permitted = yes
+		imperia_true_neutral_diplomatic_plays_permitted = yes
 		scope:target_country = {
 			NOT = { is_country_type = decentralized }
 			is_direct_subject_of = root

--- a/common/diplomatic_plays/00_diplomatic_plays.txt
+++ b/common/diplomatic_plays/00_diplomatic_plays.txt
@@ -182,7 +182,7 @@ dp_reduce_autonomy = {
 	texture = "gfx/interface/icons/war_goals/reduce_autonomy.dds"
 	
 	possible = {
-		imperia_true_neutral_diplomatic_plays_permitted = yes
+		imperia_relaxed_diplomatic_plays_permitted = yes
 		imperia_foreign_laws_permits_play = yes
 		scope:target_country = { is_subject = yes }
 	}
@@ -238,7 +238,7 @@ dp_annex_subject = {
 	texture = "gfx/interface/icons/war_goals/annex_country.dds"
 	possible = {
 		NOT = { is_country_type = decentralized }
-		imperia_true_neutral_diplomatic_plays_permitted = yes
+		imperia_relaxed_diplomatic_plays_permitted = yes
 		scope:target_country = {
 			NOT = { is_country_type = decentralized }
 			is_direct_subject_of = root

--- a/common/diplomatic_plays/00_diplomatic_plays.txt
+++ b/common/diplomatic_plays/00_diplomatic_plays.txt
@@ -111,7 +111,7 @@ dp_liberate_country = {
 
 	possible = {
 		NOT = { is_country_type = decentralized }
-		aggressive_diplomatic_plays_permitted = yes
+		imperia_aggressive_diplomatic_plays_permitted = yes
 		NOT = { is_subject_of = scope:target_country }	
 		diplomatic_play_has_no_relations_blockers = yes
 	}

--- a/common/scripted_triggers/imperia_aggressive_diplomatic_plays_permitted_custom.txt
+++ b/common/scripted_triggers/imperia_aggressive_diplomatic_plays_permitted_custom.txt
@@ -1,12 +1,16 @@
-﻿imperia_aggressive_diplomatic_plays_permitted = {
-	#Country scope
-	AND = {
-		aggressive_diplomatic_plays_permitted = yes
-		NOT = {
-			has_modifier = no_more_war
-		}
-		NOT = {
-			has_law = law_type:law_true_neutrality
-		}
+﻿imperia_true_neutral_diplomatic_plays_permitted = {
+	# For true neutral countries in very specific cases; meaning the subject autonomy relevant diplo plays for now
+	aggressive_diplomatic_plays_permitted = yes
+	NOT = {
+		has_modifier = no_more_war
+	}
+}
+
+imperia_aggressive_diplomatic_plays_permitted = {
+	# For everything else, use this one
+	# Includes everything from the other one, plus a true neutral blocker
+	imperia_true_neutral_diplomatic_plays_permitted = yes
+	NOT = {
+		has_law = law_type:law_true_neutrality
 	}
 }

--- a/common/scripted_triggers/imperia_aggressive_diplomatic_plays_permitted_custom.txt
+++ b/common/scripted_triggers/imperia_aggressive_diplomatic_plays_permitted_custom.txt
@@ -1,5 +1,6 @@
 ﻿imperia_true_neutral_diplomatic_plays_permitted = {
-	# For true neutral countries in very specific cases; meaning the subject autonomy relevant diplo plays for now
+	# For true neutral countries in very specific use-cases; meaning the subject autonomy relevant diplo plays for now
+	# Add new blockers to this trigger, in general
 	aggressive_diplomatic_plays_permitted = yes
 	NOT = {
 		has_modifier = no_more_war
@@ -7,7 +8,7 @@
 }
 
 imperia_aggressive_diplomatic_plays_permitted = {
-	# For everything else, use this one
+	# For every other use-case, use this one
 	# Includes everything from the other one, plus a true neutral blocker
 	imperia_true_neutral_diplomatic_plays_permitted = yes
 	NOT = {

--- a/common/scripted_triggers/imperia_aggressive_diplomatic_plays_permitted_custom.txt
+++ b/common/scripted_triggers/imperia_aggressive_diplomatic_plays_permitted_custom.txt
@@ -1,16 +1,28 @@
-﻿imperia_true_neutral_diplomatic_plays_permitted = {
+﻿imperia_relaxed_diplomatic_plays_permitted = {
 	# For true neutral countries in very specific use-cases; meaning the subject autonomy relevant diplo plays for now
 	# Add new blockers to this trigger, in general
 	aggressive_diplomatic_plays_permitted = yes
 	NOT = {
 		has_modifier = no_more_war
 	}
+	trigger_if = {
+		limit = { 
+			exists = scope:target_country
+			has_law = law_type:law_true_neutrality
+		}
+		scope:target_country = {
+			is_country_type = colonial
+			any_primary_culture = {
+				is_primary_culture_of = prev.overlord
+			}
+		}
+	}
 }
 
 imperia_aggressive_diplomatic_plays_permitted = {
 	# For every other use-case, use this one
 	# Includes everything from the other one, plus a true neutral blocker
-	imperia_true_neutral_diplomatic_plays_permitted = yes
+	imperia_relaxed_diplomatic_plays_permitted = yes
 	NOT = {
 		has_law = law_type:law_true_neutrality
 	}

--- a/common/scripted_triggers/imperia_aggressive_diplomatic_plays_permitted_custom.txt
+++ b/common/scripted_triggers/imperia_aggressive_diplomatic_plays_permitted_custom.txt
@@ -12,8 +12,11 @@
 		}
 		scope:target_country = {
 			is_country_type = colonial
-			any_primary_culture = {
-				is_primary_culture_of = prev.overlord
+			custom_tooltip = {
+				text = shares_primary_culture_with_overlord_tt
+				any_primary_culture = {
+					is_primary_culture_of = prev.overlord
+				}
 			}
 		}
 	}

--- a/localization/english/imperia_true_neutral_status_l_english.yml
+++ b/localization/english/imperia_true_neutral_status_l_english.yml
@@ -23,3 +23,4 @@
  true_neutral_x_needs_to_sign_tt: "[THIS.GetCountry.GetName] still needs to sign"
  true_neutral_x_have_signed_tt: "[THIS.GetCountry.GetName] have signed"
  add_journal_neutrality_treaty_tt: "Adds #variable [THIS.GetCountry.GetAdjectiveNoFormatting] Neutrality Treaty#! to the Journal of [THIS.GetCountry.GetNameNoFlag|v]"
+ shares_primary_culture_with_overlord_tt: "Shares a [Concept('concept_primary_cultures','$concept_primary_culture$')] with their [concept_overlord]"


### PR DESCRIPTION
So.. Use `imperia_aggressive_diplomatic_plays_permitted` just about everywhere. No different from before.
Use `imperia_true_neutral_diplomatic_plays_permitted` when True Neutrals should be allowed through, though.

For adding new triggers, those should in general be added to `imperia_true_neutral_diplomatic_plays_permitted`.

A bit roundabout way of doing this, but it should prove fairly expandable.