### PR TITLE
Frankfurt Parliament liberty desire dirty fix

### DIFF
--- a/common/journal_entries/imperia_frankfurt_parliament.txt
+++ b/common/journal_entries/imperia_frankfurt_parliament.txt
@@ -567,13 +567,13 @@ je_imperia_frankfurt_german_consolidation_gutter_king = {
 				}
 				if = {
 					limit = {
-						liberty_desire > 50
+						liberty_desire > 55
 					}
 					add_liberty_desire = -5
 				}
 				else_if = {
 					limit = {
-						liberty_desire < 50
+						liberty_desire < 45
 					}
 					add_liberty_desire = 5
 				}

--- a/common/journal_entries/imperia_frankfurt_parliament.txt
+++ b/common/journal_entries/imperia_frankfurt_parliament.txt
@@ -560,6 +560,24 @@ je_imperia_frankfurt_german_consolidation_gutter_king = {
 	}
 	on_weekly_pulse = {
 		effect = {
+			# Make sure that german minor subjects stay at or around 50 liberty desire, to combat any shenanigans
+			every_subject_or_below = {
+				limit = {
+					has_journal_entry = je_imperia_frankfurt_german_consolidation_german_minor
+				}
+				if = {
+					limit = {
+						liberty_desire > 50
+					}
+					add_liberty_desire = -5
+				}
+				else_if = {
+					limit = {
+						liberty_desire < 50
+					}
+					add_liberty_desire = 5
+				}
+			}
 			change_global_variable = {
 				name = frankfurt_parliament_weeks_to_civil_war
 				subtract = 1

--- a/common/scripted_effects/imperia_frankfurt_parliament_effects.txt
+++ b/common/scripted_effects/imperia_frankfurt_parliament_effects.txt
@@ -472,13 +472,12 @@ imperia_frankfurt_parliament_dissolve_gutter_germany = {
 			remove_modifier ?= gutter_king_complete_sway
 			make_independent = yes
 			# TODO in separate Frankfurt branch; re-do subject pact and/or insert to power bloc if country has the original_overlord variable
-
 		}
 	}
 	activate_law ?= var:gutter_king_old_lawgroup_governance_principles
 	activate_law ?= var:gutter_king_old_lawgroup_distribution_of_power
-	remove_modifier ?= frankfurt_gutter_king_internal_focus
 	hidden_effect = {
+		remove_modifier ?= frankfurt_gutter_king_internal_focus
 		every_in_list = {
 			variable = frankfurt_parliament_gutter_king_added_claims
 			remove_claim = prev


### PR DESCRIPTION
In 1.7, Frankfurt getting the Gutter Crown would result in rebellions, and Prussia would presumeably be able to demand integration.
This is a dirty fix, making the liberty desire of German minors (as in, they have the German Minor version of the consolidation JE) stay at or around 50 liberty desire, which resolves most issues.

Notably, the Gutter King is still spammed with requests for autonomy or own markets, but these can be safely ignored by the player...