### PR TITLE
Prevent infamy events from firing multiple times in a row

### DIFF
--- a/events/imperia_infamy_rebalance_events.txt
+++ b/events/imperia_infamy_rebalance_events.txt
@@ -548,13 +548,12 @@ infamy_rebalance.10 = {
 			value = 1.3
 		}
 		infamy >= pariah_infamy_SCOPE_VALUE_MULT_VAR_trigger
-		NOT = {
+		NOR = {
 			has_modifier = modifier_pariah_economic_sanctions
 			has_modifier = modifier_pariah_international_isolation
 		}
 	}
-	option = {
-		name = infamy_rebalance.10.a
+	immediate = {
 		add_modifier = {
 			name = modifier_pariah_economic_sanctions
 			years = 5
@@ -569,6 +568,27 @@ infamy_rebalance.10 = {
 			change_relations = {
 				country = root
 				value = -100
+			}
+		}
+	}
+	option = {
+		name = infamy_rebalance.10.a
+		show_as_tooltip = {
+			add_modifier = {
+				name = modifier_pariah_economic_sanctions
+				years = 5
+			}
+			every_country = {
+				limit = {
+					country_rank >= rank_value:great_power
+					NOT = {
+						this = root
+					}
+				}
+				change_relations = {
+					country = root
+					value = -100
+				}
 			}
 		}
 	}
@@ -597,8 +617,7 @@ infamy_rebalance.11 = {
 			has_modifier = modifier_international_pariah
 		}
 	}
-	option = {
-		name = infamy_rebalance.11.a
+	immediate = {
 		add_modifier = {
 			name = modifier_international_pariah
 		}
@@ -612,6 +631,26 @@ infamy_rebalance.11 = {
 			change_relations = {
 				country = root
 				value = -100
+			}
+		}
+	}
+	option = {
+		name = infamy_rebalance.11.a
+		show_as_tooltip = {
+			add_modifier = {
+				name = modifier_international_pariah
+			}
+			every_country = {
+				limit = {
+					country_rank >= rank_value:major_power
+					NOT = {
+						this = root
+					}
+				}
+				change_relations = {
+					country = root
+					value = -100
+				}
 			}
 		}
 	}
@@ -647,8 +686,7 @@ infamy_rebalance.12 = {
 			has_modifier = modifier_pariah_international_isolation
 		}
 	}
-	option = {
-		name = infamy_rebalance.12.a
+	immediate = {
 		add_modifier = {
 			name = modifier_pariah_international_isolation
 			years = 20
@@ -671,6 +709,36 @@ infamy_rebalance.12 = {
 				}
 				trigger_event = {
 					id = infamy_rebalance.16
+				}
+			}
+		}
+	}
+	option = {
+		name = infamy_rebalance.12.a
+		show_as_tooltip = {
+			add_modifier = {
+				name = modifier_pariah_international_isolation
+				years = 20
+			}
+			custom_tooltip = {
+				text = minus_relations_every_country_tt
+				every_country = {
+					limit = {
+						this != root
+						has_diplomatic_relevance = root
+						NOT = {
+							is_country_type = decentralized
+						}
+						NOT = {
+							has_diplomatic_pact = {
+								who = root
+								type = embargo
+							}
+						}
+					}
+					trigger_event = {
+						id = infamy_rebalance.16
+					}
 				}
 			}
 		}


### PR DESCRIPTION
The effects are now in an immediate, preventing the triggers from being true for multiple pulses at a time.
Players can still see the effects due to the presence of a `show_as_tooltip`.
There was also a `NOT` which was changed to a `NOR`, seemed to have caused the particular instance of the bug that was brought to my attention.

Oh yeah, and tested and seems to work properly :)