### PR TITLE
Crude fix for illegal redos of Frankfurt

### DIFF
--- a/common/journal_entries/imperia_frankfurt_parliament.txt
+++ b/common/journal_entries/imperia_frankfurt_parliament.txt
@@ -28,6 +28,9 @@
 			country_has_primary_culture = cu:north_german
 			country_has_primary_culture = cu:south_german
 		}
+		# Should only happen before 1850
+		# Replace with a global variable check, when possible!
+		year < 1850
 	}
 	possible = {
 		any_country = {


### PR DESCRIPTION
Frankfurt will with this fix only be redone before 1850, meant as crude fix for Pariah Enbo.