### PR TITLE
AI disabling

### DIFF
--- a/common/diplomatic_actions/04_trade_states.txt
+++ b/common/diplomatic_actions/04_trade_states.txt
@@ -1,5 +1,5 @@
 ﻿trade_states = {
-	groups= {
+	groups = {
 		general
 	}
 	
@@ -11,7 +11,7 @@
 	# catch all possibilities Diplomatic Action because Grant/Take State are currently
 	# limited to Overlords/Subjects.
 	state_selection = any_required
-
+	
 	first_state_list = first_country
 	second_state_list = second_country
 	can_use_obligations = yes
@@ -34,15 +34,15 @@
 		scope:target_country = { is_diplomatic_play_committed_participant = no }
 		has_diplomatic_relevance = scope:target_country
 		is_revolutionary = no
-		in_default = no	
-		
+		in_default = no
+
 		# Must have a connection to the state received even after the trade happens
 		trigger_if = {
 			limit = {
 				exists = scope:first_state
 				exists = scope:second_state
 			}
-		
+			
 			custom_tooltip = {
 				text = DIPLO_ACTION_TRADE_STATES_NOT_SAME_REGION
 				NOT = {
@@ -52,30 +52,30 @@
 			
 			custom_tooltip = {
 				text = DIPLO_ACTION_TRADE_STATES_WOULD_BREAK_CONNECTION
-				scope:actor = { 
+				scope:actor = {
 					any_scope_state = {
-						NOT = { this = scope:first_state }	
+						NOT = { this = scope:first_state }
 						OR = {
 							any_neighbouring_state = { this = scope:second_state }
 							AND = {
 								is_coastal = yes
 								scope:second_state = { is_coastal = yes }
 							}
-						}						
-					}					
-				}					
-				scope:target_country = { 
+						}
+					}
+				}
+				scope:target_country = {
 					any_scope_state = {
-						NOT = { this = scope:second_state }	
+						NOT = { this = scope:second_state }
 						OR = {
 							any_neighbouring_state = { this = scope:first_state }
 							AND = {
 								is_coastal = yes
 								scope:first_state = { is_coastal = yes }
 							}
-						}						
-					}					
-				}						
+						}
+					}
+				}
 			}
 		}
 	}
@@ -88,7 +88,7 @@
 		if = {
 			limit = { exists = scope:second_state }
 			scope:second_state = { set_state_owner = root }
-		}		
+		}
 	}
 	
 	first_state_trigger = {
@@ -98,7 +98,7 @@
 		OR = {
 			scope:target_country = { is_adjacent_to_state = root }
 			AND = {
-				is_coastal = yes		
+				is_coastal = yes
 				scope:target_country = { has_port = yes }
 			}
 		}
@@ -111,23 +111,23 @@
 		OR = {
 			scope:country = { is_adjacent_to_state = root }
 			AND = {
-				is_coastal = yes		
+				is_coastal = yes
 				scope:country = { has_port = yes }
 			}
-		}		
-	}	
+		}
+	}
 	
 	ai = {
 		check_acceptance_for_will_propose = yes
 		
 		evaluation_chance = {
 			value = 0.1
-		}			
-	
+		}
+		
 		propose_score = {
 			value = 10
 		}
-		
+
 		# Selection triggers exist only to pre-filter which state combinations the AI looks at
 		# This is done for performance reasons - the more open ended these triggers are, the more it will impact performance
 		will_select_as_first_state = {
@@ -136,7 +136,7 @@
 			is_incorporated = no
 			NOT = { is_homeland_of_country_cultures = owner }
 			state_is_in_africa = yes
-			NOT = { state_region = s:STATE_INDIAN_OCEAN_TERRITORY } # Special exception to african state trading
+			NOT = { state_region = s:STATE_INDIAN_OCEAN_TERRITORY }	# Special exception to african state trading
 		}
 		
 		will_select_as_second_state = {
@@ -145,26 +145,26 @@
 			is_incorporated = no
 			NOT = { is_homeland_of_country_cultures = owner }
 			state_is_in_africa = yes
-			NOT = { state_region = s:STATE_INDIAN_OCEAN_TERRITORY } # Special exception to african state trading
-		}		
+			NOT = { state_region = s:STATE_INDIAN_OCEAN_TERRITORY }	# Special exception to african state trading
+		}
 		
 		will_propose_with_states = {
 			exists = scope:first_state
-			exists = scope:second_state	
+			exists = scope:second_state
 			NOT = { scope:first_state.state_region = scope:second_state.state_region }
-			scope:first_state = { 
-				is_split_state = yes	
-				state_region = { 
+			scope:first_state = {
+				is_split_state = yes
+				state_region = {
 					any_scope_state = { owner = scope:target_country }
 				}
-			}	
-			scope:second_state = { 
+			}
+			scope:second_state = {
 				is_split_state = yes
-				state_region = { 
+				state_region = {
 					any_scope_state = { owner = root }
 				}
-			}			
-		}	
+			}
+		}
 		
 		accept_score = {
 			value = 0
@@ -187,7 +187,7 @@
 				add = {
 					desc = "DIPLOMATIC_ACCEPTANCE_STATES_NOT_SET"
 					value = -1000
-				}				
+				}
 			}
 			else = {
 				if = {
@@ -195,65 +195,65 @@
 						exists = scope:second_state
 					}
 					subtract = {
-						value = scope:second_state.ai_state_value:root	
+						value = scope:second_state.ai_state_value:root
 						desc = "DIPLOMATIC_ACCEPTANCE_TRADE_STATE_SECOND_STATE"
 						min = 10
 					}
-				}	
-				else_if = {		
+				}
+				else_if = {
 					add = {
-						value = 100	
-						desc = "DIPLOMATIC_ACCEPTANCE_GIVING_AWAY_LAND"						
-					}			
-				}			
-
+						value = 100
+						desc = "DIPLOMATIC_ACCEPTANCE_GIVING_AWAY_LAND"
+					}
+				}
+				
 				if = {
 					limit = {
-						exists = scope:first_state				
+						exists = scope:first_state
 					}
 					if = {
 						limit = { scope:first_state.ai_state_value:root > 0 }
 						add = {
-							value = scope:first_state.ai_state_value:root	
-							desc = "DIPLOMATIC_ACCEPTANCE_TRADE_STATE_FIRST_STATE"						
-						}				
+							value = scope:first_state.ai_state_value:root
+							desc = "DIPLOMATIC_ACCEPTANCE_TRADE_STATE_FIRST_STATE"
+						}
 					}
 					else = {
 						add = {
-							value = -1000	
-							desc = "DIPLOMATIC_ACCEPTANCE_DOES_NOT_WANT_FIRST_STATE"						
-						}					
+							value = -1000
+							desc = "DIPLOMATIC_ACCEPTANCE_DOES_NOT_WANT_FIRST_STATE"
+						}
 					}
 				}
-
+				
 				if = {
 					limit = {
 						exists = scope:first_state
-						exists = scope:second_state						
-						scope:first_state = { 
+						exists = scope:second_state
+						scope:first_state = {
 							is_split_state = yes
-							state_region = { 
+							state_region = {
 								any_scope_state = { owner = root }
 							}
-						}	
-						scope:second_state = { 
+						}
+						scope:second_state = {
 							is_split_state = yes
-							state_region = { 
+							state_region = {
 								any_scope_state = { owner = scope:actor }
 							}
-						}						
+						}
 					}
-
+					
 					add = {
 						value = 25
-						desc = "DIPLOMATIC_ACCEPTANCE_TRADE_STATE_SPLIT_STATE_EXCHANGE"						
-					}						
+						desc = "DIPLOMATIC_ACCEPTANCE_TRADE_STATE_SPLIT_STATE_EXCHANGE"
+					}
 				}
-			}	
+			}
 			
 			add = {
 				desc = "DIPLOMATIC_ACCEPTANCE_PRINCIPLE_SACRED_CIVICS"
-
+				
 				if = {
 					limit = {
 						AND = {
@@ -269,7 +269,7 @@
 					}
 					add = 10
 				}
-			}			
+			}
 		}
 		
 		use_obligation_chance = {
@@ -278,20 +278,20 @@
 			if = {
 				limit = {
 					scope:target_country = { country_rank > root.country_rank }
-				}				
+				}
 				add = 20
-			}				
+			}
 		}
 		
 		owe_obligation_chance = {
-			value = 0	
-
+			value = 0
+			
 			if = {
 				limit = {
 					scope:target_country = { country_rank > root.country_rank }
-				}				
+				}
 				add = 10
-			}				
-		}		
+			}
+		}
 	}
 }

--- a/common/journal_entries/imperia_disable_ai.txt
+++ b/common/journal_entries/imperia_disable_ai.txt
@@ -7,7 +7,7 @@
 	possible = {
 		is_ai = yes
 		OR = {
-			has_variable = is_player
+			has_variable = detected_player
 			# Once the timer is up, this JE will disappear
 			has_variable = ai_disabled_timer
 		}
@@ -17,7 +17,7 @@
 		imperia_ai_disabled
 	}
 	immediate = {
-		remove_variable = is_player
+		remove_variable = detected_player
 		set_variable = {
 			name = ai_disabled_timer
 			years = 8

--- a/common/journal_entries/imperia_disable_ai.txt
+++ b/common/journal_entries/imperia_disable_ai.txt
@@ -1,0 +1,29 @@
+﻿je_disable_ai = {
+	icon = "gfx/interface/icons/invention_icons/wargaming.dds"
+	group = je_group_internal_affairs
+	is_shown_when_inactive = {
+		is_ai = yes
+	}
+	possible = {
+		is_ai = yes
+		OR = {
+			has_variable = is_player
+			# Once the timer is up, this JE will disappear
+			has_variable = ai_disabled_timer
+		}
+	}
+	modifiers_while_active = {
+		# This modifier disables downsizing and privatization
+		imperia_ai_disabled
+	}
+	immediate = {
+		remove_variable = is_player
+		set_variable = {
+			name = ai_disabled_timer
+			years = 8
+		}
+	}
+	# The deactivating returns it promptly to being inactive, if the possible section equals false. But also means no "on_x" (complete, invalid, fail) can trigger. 
+	can_deactivate = yes
+	# The variables are therefore handled in the on_actions, no on_complete or anything, since those wouldnt be used.
+}

--- a/common/on_actions/imperia_on_monthtly_pulse.txt
+++ b/common/on_actions/imperia_on_monthtly_pulse.txt
@@ -29,8 +29,8 @@
 				value = {
 					add = local_var:total_infrastructure
 					divide = local_var:number_of_states
-					subtract = 50	# counting from 50 infrasturucture
-					divide = 8	# every 8 infrastructure average is 1 land_trade capacity
+					subtract = 50					# counting from 50 infrasturucture
+					divide = 8					# every 8 infrastructure average is 1 land_trade capacity
 				}
 			}
 			if = {
@@ -261,13 +261,26 @@
 				remove_variable = imperia_ig_lobby_membership_timer
 			}
 		}
+		## AI Disabling
+		# Sets the is_player variable for new/reconnecting players
+		if = {
+			limit = {
+				is_player = yes
+				NOT = {
+					has_variable = is_player
+				}
+			}
+			# Removes the AI disabling timer (if its there) in case the player is hotjoining in again.
+			remove_variable ?= ai_disabled_timer
+			set_variable = is_player
+		}
 	}
 	random_events = {
 		23 = 0
 		1 = dead_man.3
 	}
 	events = {
-		infamy_rebalance.1	#updates provinces each month
+		infamy_rebalance.1		#updates provinces each month
 	}
 }
 

--- a/common/on_actions/imperia_on_monthtly_pulse.txt
+++ b/common/on_actions/imperia_on_monthtly_pulse.txt
@@ -29,8 +29,8 @@
 				value = {
 					add = local_var:total_infrastructure
 					divide = local_var:number_of_states
-					subtract = 50					# counting from 50 infrasturucture
-					divide = 8					# every 8 infrastructure average is 1 land_trade capacity
+					subtract = 50	# counting from 50 infrasturucture
+					divide = 8	# every 8 infrastructure average is 1 land_trade capacity
 				}
 			}
 			if = {
@@ -280,7 +280,7 @@
 		1 = dead_man.3
 	}
 	events = {
-		infamy_rebalance.1		#updates provinces each month
+		infamy_rebalance.1	#updates provinces each month
 	}
 }
 

--- a/common/on_actions/imperia_on_monthtly_pulse.txt
+++ b/common/on_actions/imperia_on_monthtly_pulse.txt
@@ -267,12 +267,12 @@
 			limit = {
 				is_player = yes
 				NOT = {
-					has_variable = is_player
+					has_variable = detected_player
 				}
 			}
 			# Removes the AI disabling timer (if its there) in case the player is hotjoining in again.
 			remove_variable ?= ai_disabled_timer
-			set_variable = is_player
+			set_variable = detected_player
 		}
 	}
 	random_events = {

--- a/common/static_modifiers/imperia_modifiers.txt
+++ b/common/static_modifiers/imperia_modifiers.txt
@@ -76,6 +76,12 @@ afro_american_acceptance = {
 	country_prestige_add = 50
 }
 
+imperia_ai_disabled = {
+	icon = gfx/interface/icons/timed_modifier_icons/modifier_gear_negative.dds
+	country_disable_privatization_bool = yes
+	country_all_buildings_protected_bool = yes
+}
+
 #########################
 ### POLITICAL DISCORD ###
 #########################

--- a/localization/english/imperia_misc_l_english.yml
+++ b/localization/english/imperia_misc_l_english.yml
@@ -160,4 +160,8 @@
  victoria.3.b: "We must give in."
  victoria.3.nopu: "We will fight to maintain our independence!"
  victoria.3.pu: "We will concede to Victoria's demands and return to a Personal Union."
-
+ 
+ # Disable AI stuff
+ je_disable_ai: "#r AI Partially Disabled#!"
+ je_disable_ai_reason: "This country has been #r banned#! from privatising and downsizing buildings, due to the AI taking over from the human player. This will be lifted once a player rejoins or 8 years pass.\n#lore Please contact the Imperia Roleplay mod team if this does not disappear.#!"
+ imperia_ai_disabled: "AI Disabled"


### PR DESCRIPTION
With a `can_deactivate = yes` in the JE, it will remove itself for reuse if the `possible` is false.
It won't pop an `on_X` though, doing this, so I added a teeny bit more to the on_action than we thought would be needed.

Mind you, this is something we haven't used before, and ingame it kinda feels like a plug is being pulled on the JE, it doesn't seem graceful. Just throwing it out there; that I'm not sure about limitations and potential quirks of it.

The 8-year timer will go on for up to a month before being removed, if a player reconnects. Shouldn't harm anything though, since it WILL be removed since the timer removal is tied to the `is_player` var renewal.