### PR TITLE
Mobilization options for 1.8.1

### DIFF
--- a/common/mobilization_options/00_mobilization_option.txt
+++ b/common/mobilization_options/00_mobilization_option.txt
@@ -11,7 +11,6 @@
 		goods_input_meat_add = 0.1
 	}
 	upkeep_modifier_unscaled = {
-<<<<<<< HEAD
 		goods_input_small_arms_mult = 0.1
 		goods_input_artillery_mult = 0.1
 		goods_input_ammunition_mult = 0.1
@@ -26,14 +25,6 @@
 		goods_input_groceries_mult = 0.1
 		goods_input_fruit_mult = 0.1
 		goods_input_meat_mult = 0.1
-=======
-		goods_input_small_arms_mult = 0.25
-		goods_input_artillery_mult = 0.25
-		goods_input_ammunition_mult = 0.25
-		goods_input_oil_mult = 0.25
-		goods_input_radios_mult = 0.25
-		goods_input_tanks_mult = 0.25
->>>>>>> 093a8c32 (V1.8.1)
 	}
 	unit_modifier = {
 		# empty on purpose - this is the minimum mobilization cost
@@ -41,19 +32,11 @@
 	ai_weight = {
 		value = 1
 	}
-<<<<<<< HEAD
-=======
-	
->>>>>>> 093a8c32 (V1.8.1)
 	group = supplies
 }
 
 mobilization_option_extra_supplies = {
 	texture = "gfx/interface/icons/mobilization_options/extra_supplies.dds"
-<<<<<<< HEAD
-=======
-	
->>>>>>> 093a8c32 (V1.8.1)
 	possible = {
 		market ?= {
 			mg:groceries ?= {
@@ -64,10 +47,6 @@ mobilization_option_extra_supplies = {
 	unlocking_technologies = {
 		army_reserves
 	}
-<<<<<<< HEAD
-=======
-	
->>>>>>> 093a8c32 (V1.8.1)
 	on_deactivate_while_mobilized = {
 		custom_tooltip = {
 			text = mobilization_option_it_hurts_morale_when_you_remove_supplies_while_in_combat_tt
@@ -84,7 +63,6 @@ mobilization_option_extra_supplies = {
 		goods_input_meat_add = 0.4
 	}
 	upkeep_modifier_unscaled = {
-<<<<<<< HEAD
 		goods_input_small_arms_mult = 0.2
 		goods_input_artillery_mult = 0.2
 		goods_input_ammunition_mult = 0.2
@@ -100,16 +78,6 @@ mobilization_option_extra_supplies = {
 		goods_input_fruit_mult = 0.2
 		goods_input_meat_mult = 0.2
 	}
-=======
-		goods_input_small_arms_mult = 0.25
-		goods_input_artillery_mult = 0.25
-		goods_input_ammunition_mult = 0.25
-		goods_input_oil_mult = 0.25
-		goods_input_radios_mult = 0.25
-		goods_input_tanks_mult = 0.25
-	}
-	
->>>>>>> 093a8c32 (V1.8.1)
 	unit_modifier = {
 		unit_morale_loss_mult = -0.05
 		unit_offense_mult = 0.1
@@ -118,19 +86,11 @@ mobilization_option_extra_supplies = {
 	ai_weight = {
 		value = 1
 	}
-<<<<<<< HEAD
-=======
-	
->>>>>>> 093a8c32 (V1.8.1)
 	group = supplies
 }
 
 mobilization_option_luxurious_supplies = {
 	texture = "gfx/interface/icons/mobilization_options/luxurious_supplies.dds"
-<<<<<<< HEAD
-=======
-	
->>>>>>> 093a8c32 (V1.8.1)
 	possible = {
 		scope:military_formation = {
 			has_mobilization_option = mobilization_option:mobilization_option_extra_supplies
@@ -164,7 +124,6 @@ mobilization_option_luxurious_supplies = {
 		goods_input_wine_add = 1
 	}
 	upkeep_modifier_unscaled = {
-<<<<<<< HEAD
 		goods_input_small_arms_mult = 0.3
 		goods_input_artillery_mult = 0.3
 		goods_input_ammunition_mult = 0.3
@@ -180,16 +139,6 @@ mobilization_option_luxurious_supplies = {
 		goods_input_fruit_mult = 0.3
 		goods_input_meat_mult = 0.3
 	}
-=======
-		goods_input_small_arms_mult = 0.25
-		goods_input_artillery_mult = 0.25
-		goods_input_ammunition_mult = 0.25
-		goods_input_oil_mult = 0.25
-		goods_input_radios_mult = 0.25
-		goods_input_tanks_mult = 0.25
-	}
-	
->>>>>>> 093a8c32 (V1.8.1)
 	unit_modifier = {
 		unit_morale_loss_mult = -0.1
 		unit_offense_mult = 0.15
@@ -198,19 +147,11 @@ mobilization_option_luxurious_supplies = {
 	ai_weight = {
 		value = 1
 	}
-<<<<<<< HEAD
-=======
-	
->>>>>>> 093a8c32 (V1.8.1)
 	group = supplies
 }
 
 mobilization_option_chocolate = {
 	texture = "gfx/interface/icons/mobilization_options/chocolate.dds"
-<<<<<<< HEAD
-=======
-	
->>>>>>> 093a8c32 (V1.8.1)
 	possible = {
 		market ?= {
 			mg:sugar ?= {
@@ -218,10 +159,6 @@ mobilization_option_chocolate = {
 			}
 		}
 	}
-<<<<<<< HEAD
-=======
-	
->>>>>>> 093a8c32 (V1.8.1)
 	on_deactivate_while_mobilized = {
 		custom_tooltip = {
 			text = mobilization_option_it_hurts_morale_when_you_remove_supplies_while_in_combat_tt
@@ -233,10 +170,6 @@ mobilization_option_chocolate = {
 			}
 		}
 	}
-<<<<<<< HEAD
-=======
-	
->>>>>>> 093a8c32 (V1.8.1)
 	upkeep_modifier = {
 		goods_input_sugar_add = 1.25
 	}
@@ -246,19 +179,11 @@ mobilization_option_chocolate = {
 	ai_weight = {
 		value = 1
 	}
-<<<<<<< HEAD
-=======
-	
->>>>>>> 093a8c32 (V1.8.1)
 	group = supplements
 }
 
 mobilization_option_tobacco = {
 	texture = "gfx/interface/icons/mobilization_options/tobacco.dds"
-<<<<<<< HEAD
-=======
-	
->>>>>>> 093a8c32 (V1.8.1)
 	possible = {
 		market ?= {
 			mg:tobacco ?= {
@@ -286,19 +211,11 @@ mobilization_option_tobacco = {
 	ai_weight = {
 		value = 1
 	}
-<<<<<<< HEAD
-=======
-	
->>>>>>> 093a8c32 (V1.8.1)
 	group = supplements
 }
 
 mobilization_option_liquor = {
 	texture = "gfx/interface/icons/mobilization_options/liquor.dds"
-<<<<<<< HEAD
-=======
-	
->>>>>>> 093a8c32 (V1.8.1)
 	possible = {
 		market ?= {
 			mg:liquor ?= {
@@ -327,19 +244,11 @@ mobilization_option_liquor = {
 	ai_weight = {
 		value = 1
 	}
-<<<<<<< HEAD
-=======
-	
->>>>>>> 093a8c32 (V1.8.1)
 	group = supplements
 }
 
 mobilization_option_opium = {
 	texture = "gfx/interface/icons/mobilization_options/opium.dds"
-<<<<<<< HEAD
-=======
-	
->>>>>>> 093a8c32 (V1.8.1)
 	possible = {
 		market ?= {
 			mg:opium ?= {
@@ -369,10 +278,6 @@ mobilization_option_opium = {
 	ai_weight = {
 		value = 1
 	}
-<<<<<<< HEAD
-=======
-	
->>>>>>> 093a8c32 (V1.8.1)
 	group = supplements
 }
 
@@ -422,10 +327,6 @@ mobilization_option_forced_march = {
 			add = 1
 		}
 	}
-<<<<<<< HEAD
-=======
-	
->>>>>>> 093a8c32 (V1.8.1)
 	group = transport
 }
 
@@ -475,10 +376,6 @@ mobilization_option_truck_transport = {
 	ai_weight = {
 		value = 1
 	}
-<<<<<<< HEAD
-=======
-	
->>>>>>> 093a8c32 (V1.8.1)
 	group = transport
 }
 
@@ -527,7 +424,6 @@ mobilization_option_rail_transport = {
 	ai_weight = {
 		value = 1
 	}
-<<<<<<< HEAD
 	group = transport
 }
 
@@ -578,18 +474,10 @@ mobilization_option_grenades = {
 		value = 1
 	}
 	group = special_weapons
-=======
-	
-	group = transport
->>>>>>> 093a8c32 (V1.8.1)
 }
 
 mobilization_option_machinegunners = {
 	texture = "gfx/interface/icons/mobilization_options/machinegunners.dds"
-<<<<<<< HEAD
-=======
-	
->>>>>>> 093a8c32 (V1.8.1)
 	possible = {
 		market ?= {
 			mg:ammunition ?= {
@@ -629,19 +517,11 @@ mobilization_option_machinegunners = {
 	ai_weight = {
 		value = 1
 	}
-<<<<<<< HEAD
-=======
-	
->>>>>>> 093a8c32 (V1.8.1)
 	group = special_weapons
 }
 
 mobilization_option_chemical_weapons = {
 	texture = "gfx/interface/icons/mobilization_options/chemical_weapons.dds"
-<<<<<<< HEAD
-=======
-	
->>>>>>> 093a8c32 (V1.8.1)
 	possible = {
 		market ?= {
 			mg:fertilizer ?= {
@@ -684,19 +564,11 @@ mobilization_option_chemical_weapons = {
 	ai_weight = {
 		value = 1
 	}
-<<<<<<< HEAD
-=======
-	
->>>>>>> 093a8c32 (V1.8.1)
 	group = special_weapons
 }
 
 mobilization_option_flamethrowers = {
 	texture = "gfx/interface/icons/mobilization_options/flamethrowers.dds"
-<<<<<<< HEAD
-=======
-	
->>>>>>> 093a8c32 (V1.8.1)
 	possible = {
 		market ?= {
 			mg:oil ?= {
@@ -739,7 +611,6 @@ mobilization_option_flamethrowers = {
 	ai_weight = {
 		value = 1
 	}
-<<<<<<< HEAD
 	group = special_weapons
 }
 
@@ -792,9 +663,6 @@ mobilization_option_modern_fortifications = {
 	ai_weight = {
 		value = 1
 	}
-=======
-	
->>>>>>> 093a8c32 (V1.8.1)
 	group = special_weapons
 }
 
@@ -810,14 +678,8 @@ mobilization_option_modern_fortifications = {
 # 		#needs code support to reduce naval invasion penalty
 # 	}
 # 	ai_weight = {
-<<<<<<< HEAD
 # 	value = 1
 # }
-=======
-#		value = 1
-#	}
-#
->>>>>>> 093a8c32 (V1.8.1)
 #     group = special_weapons
 # }
 mobilization_option_infantry_recon = {
@@ -940,10 +802,6 @@ mobilization_option_cavalry_recon = {
 
 mobilization_option_motorized_recon = {
 	texture = "gfx/interface/icons/mobilization_options/motorized_reconaissance.dds"
-<<<<<<< HEAD
-=======
-	
->>>>>>> 093a8c32 (V1.8.1)
 	possible = {
 		NOR = {
 			scope:military_formation = {
@@ -1000,126 +858,11 @@ mobilization_option_motorized_recon = {
 	ai_weight = {
 		value = 1
 	}
-<<<<<<< HEAD
 	
-=======
-	
-	group = reconnaissance
-}
-
-mobilization_option_balloon_recon = {
-	texture = "gfx/interface/icons/mobilization_options/balloon_recon.dds"
-	
-	unlocking_principles = {
-		principle_military_industry_3
-	}
-	
-	possible = {
-		market ?= {
-			mg:fabric ?= {
-				market_goods_sell_orders > 0
-			}
-			mg:oil ?= {
-				market_goods_sell_orders > 0
-			}
-		}
-	}
-	
-	on_activate_while_mobilized = {
-		custom_tooltip = {
-			text = mobilization_option_it_hurts_organization_when_you_adjust_equipment_tt
-			add_organization = {
-				value = organization
-				multiply = -0.5
-			}
-		}
-	}
-	
-	on_deactivate = {
-		custom_tooltip = {
-			text = mobilization_option_it_hurts_organization_when_you_adjust_equipment_tt
-			add_organization = {
-				value = organization
-				multiply = -0.25
-			}
-		}
-	}
-	
-	upkeep_modifier = {
-		goods_input_fabric_add = 2
-		goods_input_oil_add = 0.5
-	}
-	unit_modifier = {
-		unit_occupation_mult = 0.8
-		military_formation_attrition_risk_mult = -0.2
-		character_battle_condition_charted_terrain_mult = 0.5
-	}
-	ai_weight = {
-		value = 1
-	}
-	
-	group = reconnaissance
-}
-
-mobilization_option_aerial_recon = {
-	texture = "gfx/interface/icons/mobilization_options/aerial_reconaissance.dds"
-	
-	possible = {
-		market ?= {
-			mg:aeroplanes ?= {
-				market_goods_sell_orders > 0
-			}
-			mg:oil ?= {
-				market_goods_sell_orders > 0
-			}
-		}
-	}
-	
-	on_activate_while_mobilized = {
-		custom_tooltip = {
-			text = mobilization_option_it_hurts_organization_when_you_adjust_equipment_tt
-			add_organization = {
-				value = organization
-				multiply = -0.5
-			}
-		}
-	}
-	
-	on_deactivate = {
-		custom_tooltip = {
-			text = mobilization_option_it_hurts_organization_when_you_adjust_equipment_tt
-			add_organization = {
-				value = organization
-				multiply = -0.5
-			}
-		}
-	}
-	
-	unlocking_technologies = {
-		military_aviation
-	}
-	upkeep_modifier = {
-		goods_input_aeroplanes_add = 1
-		goods_input_oil_add = 0.5
-	}
-	unit_modifier = {
-		unit_occupation_mult = 1
-		character_battle_condition_rapid_advance_mult = 1
-		character_battle_condition_lost_mult = -0.5
-	}
-	ai_weight = {
-		value = 1
-	}
-	
->>>>>>> 093a8c32 (V1.8.1)
 	group = reconnaissance
 }
 
 mobilization_option_first_aid = {
-<<<<<<< HEAD
-=======
-	
->>>>>>> 093a8c32 (V1.8.1)
 	unlocking_technologies = {
 		triage
 	}
@@ -1178,19 +921,11 @@ mobilization_option_first_aid = {
 	ai_weight = {
 		value = 1
 	}
-<<<<<<< HEAD
-=======
-	
->>>>>>> 093a8c32 (V1.8.1)
 	group = medic_support
 }
 
 mobilization_option_field_hospitals = {
 	texture = "gfx/interface/icons/mobilization_options/field_hospitals.dds"
-<<<<<<< HEAD
-=======
-	
->>>>>>> 093a8c32 (V1.8.1)
 	unlocking_technologies = {
 		modern_nursing
 	}
@@ -1245,16 +980,11 @@ mobilization_option_field_hospitals = {
 		goods_input_liquor_add = 1
 	}
 	unit_modifier = {
-<<<<<<< HEAD
 		unit_recovery_rate_add = 0.45
-=======
-		unit_recovery_rate_add = 0.40
->>>>>>> 093a8c32 (V1.8.1)
 	}
 	ai_weight = {
 		value = 1
 	}
-<<<<<<< HEAD
 	group = medic_support
 }
 
@@ -1320,8 +1050,5 @@ mobilization_option_great_war_medicine = {
 	ai_weight = {
 		value = 1
 	}
-=======
-	
->>>>>>> 093a8c32 (V1.8.1)
 	group = medic_support
 }


### PR DESCRIPTION
Recon balloons and scout planes are already part of our own aerial support category, hence why they get deleted