### PR TITLE
Moved congress parade budget options to gdp from weekly_net_fixed_income

### DIFF
--- a/events/conference_events/imperia_vienna_congress_random_events.txt
+++ b/events/conference_events/imperia_vienna_congress_random_events.txt
@@ -1904,36 +1904,40 @@ congress_random_event.14 = {
 		set_variable = {
 			name = very_low_budget_amount
 			value = {
-				value = weekly_net_fixed_income
-				multiply = 0.15
+				value = gdp
+				divide = 3000
 			}
 		}
 		set_variable = {
 			name = low_budget_amount
 			value = {
-				value = weekly_net_fixed_income
-				multiply = 0.3
+				value = gdp
+				divide = 3000
+				multiply = 2
 			}
 		}
 		set_variable = {
 			name = medium_budget_amount
 			value = {
-				value = weekly_net_fixed_income
-				multiply = 0.45
+				value = gdp
+				divide = 3000
+				multiply = 3
 			}
 		}
 		set_variable = {
 			name = high_budget_amount
 			value = {
-				value = weekly_net_fixed_income
-				multiply = 0.6
+				value = gdp
+				divide = 3000
+				multiply = 4
 			}
 		}
 		set_variable = {
 			name = very_high_budget_amount
 			value = {
-				value = weekly_net_fixed_income
-				multiply = 0.75
+				value = gdp
+				divide = 3000
+				multiply = 5
 			}
 		}
 		congress_parade_invite_lead = yes
@@ -2168,36 +2172,40 @@ congress_random_event.16 = {
 		set_variable = {
 			name = very_low_budget_amount
 			value = {
-				value = weekly_net_fixed_income
-				multiply = 0.15
+				value = gdp
+				divide = 3000
 			}
 		}
 		set_variable = {
 			name = low_budget_amount
 			value = {
-				value = weekly_net_fixed_income
-				multiply = 0.3
+				value = gdp
+				divide = 3000
+				multiply = 2
 			}
 		}
 		set_variable = {
 			name = medium_budget_amount
 			value = {
-				value = weekly_net_fixed_income
-				multiply = 0.45
+				value = gdp
+				divide = 3000
+				multiply = 3
 			}
 		}
 		set_variable = {
 			name = high_budget_amount
 			value = {
-				value = weekly_net_fixed_income
-				multiply = 0.6
+				value = gdp
+				divide = 3000
+				multiply = 4
 			}
 		}
 		set_variable = {
 			name = very_high_budget_amount
 			value = {
-				value = weekly_net_fixed_income
-				multiply = 0.75
+				value = gdp
+				divide = 3000
+				multiply = 5
 			}
 		}
 	}


### PR DESCRIPTION
The budgets being divided by 3000 multiplied by X is mostly out of the hat, 3000 seemed to be an acceptable level, and the multiplier (X, being the budget level) seemed natural, although it probably could be scaling a bit harder? Like, I was considering 1.2 x level, but... Might be unnecessary complications.

Nevertheless, this will work as long as the country doesn't go into the negative GDPs. Which is _probably_ not possible.