### PR TITLE
Reintroduction of the topbar lock toggle

### DIFF
--- a/gui/topbar.gui
+++ b/gui/topbar.gui
@@ -781,50 +781,50 @@ types topbar_components
 			}
 
 			### LOCK TOGGLE FOR SECONDARY ROW OF ICONS
-			# button_icon_round_toggle = {
-			# 	visible = "[GetMetaPlayer.GetPlayedOrObservedCountry.IsValid]"
-			# 	size = { 24 24 }
-			# 	parentanchor = bottom|right
-			# 	position = { -30 -9 }
+			button_icon_round_toggle = {
+				visible = "[GetMetaPlayer.GetPlayedOrObservedCountry.IsValid]"
+				size = { 24 24 }
+				parentanchor = top|right # Was bottom|right, but that leaves it outside of the window...
+				position = { -57 5 } # Was -30 -9, but that leaves it outside of the window...
 				
-			# 	alpha = 0
+				alpha = 0
 				
-			# 	state = {
-			# 		name = show_topbar_secondary_stats
-			# 		delay = 0.15
-			# 		alpha = 1
-			# 		duration = 0.15
-			# 		using = Animation_Curve_Default
-			# 	}
-			# 	state = {
-			# 		name = hide_topbar_secondary_stats
-			# 		alpha = 0
-			# 		duration = 0
-			# 		using = Animation_Curve_Default
-			# 	}
+				state = {
+					name = show_topbar_secondary_stats
+					delay = 0.15
+					alpha = 1
+					duration = 0.15
+					using = Animation_Curve_Default
+				}
+				state = {
+					name = hide_topbar_secondary_stats
+					alpha = 0
+					duration = 0
+					using = Animation_Curve_Default
+				}
 				
-			# 	blockoverride "on_click" {
-			# 		onclick = "[GetVariableSystem.Toggle('more_topbar_info')]"
-			# 	}
-			# 	blockoverride "view_1" {
-			# 		visible = "[GetVariableSystem.Exists('more_topbar_info')]"
-			# 	}
-			# 	blockoverride "view_2" {
-			# 		visible = "[Not(GetVariableSystem.Exists('more_topbar_info'))]"
-			# 	}
-			# 	blockoverride "icon_1" {
-			# 		texture = "gfx/interface/buttons/button_icons/unlock.dds"
-			# 	}
-			# 	blockoverride "icon_2" {
-			# 		texture = "gfx/interface/buttons/button_icons/lock.dds"
-			# 	}
-			# 	blockoverride "tooltip_1" {
-			# 		tooltip = "LOCK_TOPBAR"
-			# 	}
-			# 	blockoverride "tooltip_2" {
-			# 		tooltip = "UNLOCK_TOPBAR"
-			# 	}
-			# }
+				blockoverride "on_click" {
+					onclick = "[GetVariableSystem.Toggle('more_topbar_info')]"
+				}
+				blockoverride "view_1" {
+					visible = "[GetVariableSystem.Exists('more_topbar_info')]"
+				}
+				blockoverride "view_2" {
+					visible = "[Not(GetVariableSystem.Exists('more_topbar_info'))]"
+				}
+				blockoverride "icon_1" {
+					texture = "gfx/interface/buttons/button_icons/unlock.dds"
+				}
+				blockoverride "icon_2" {
+					texture = "gfx/interface/buttons/button_icons/lock.dds"
+				}
+				blockoverride "tooltip_1" {
+					tooltip = "LOCK_TOPBAR"
+				}
+				blockoverride "tooltip_2" {
+					tooltip = "UNLOCK_TOPBAR"
+				}
+			}
 			
 			### FLAG
 			fancy_flag = {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/e8fb552f-3703-49a3-9bad-459ad7d32df7)
![image](https://github.com/user-attachments/assets/1adafa7c-3f40-41b9-9c50-1be299cd11c6)

Due to the changes we've made to the topbar, the lock toggle would hover outside the topbar. I've changed its position and tuned its position.. Should be fine there.